### PR TITLE
fix: Enumeration exponentially improved by fixing bug in `enumerate`

### DIFF
--- a/Plausible/Chamelean/MExp.lean
+++ b/Plausible/Chamelean/MExp.lean
@@ -338,7 +338,6 @@ mutual
       -- i.e. check if an instance for `ArbitrarySizedSuchThat` / `EnumSizedSuchThat` with the
       -- specified `argTys` and `prop` already exists
       let (args, argTys) := List.unzip varsTys
-      -- let argTyTerms ← monadLift $ argTys.toArray.mapM constructorExprToTSyntaxTerm
       let argTyExprs := argTys.map (Option.map ToExpr.toExpr)
       let typedArgs := List.zip args argTyExprs
       let argsTuple ← mkTuple typedArgs
@@ -362,7 +361,7 @@ mutual
 end
 
 def nameAndConstructorExprToTypedVar (v : Name × Option ConstructorExpr) : Name × Option Expr :=
-  Prod.map id (ToExpr.toExpr <$> .) v
+  Prod.map id (ToExpr.toExpr <$> ·) v
 
 /-- Compiles a `ScheduleStep` to an `MExp`.
      Note that `MExp` that is returned by this function is represented
@@ -376,8 +375,6 @@ def nameAndConstructorExprToTypedVar (v : Name × Option ConstructorExpr) : Name
     - `mfuel` and `defFuel` are `MExp`s representing the current size and the initial size
       supplied to the generator/enumerator/checker we're deriving
 -/
-
--- #eval elabType `(String)
 
 def scheduleStepToMExp (step : ScheduleStep) (defFuel : MExp) (k : MExp) (outputType : Expr) : CompileScheduleM MExp :=
   match step with

--- a/Plausible/Chamelean/MExp.lean
+++ b/Plausible/Chamelean/MExp.lean
@@ -302,7 +302,7 @@ mutual
               mkTuple vars
           -- We pass in `(min 2 initSize)` as the amount of fuel for the enumerator to avoid stack-overflow
           -- See https://github.com/ngernest/chamelean/issues/40 for details
-          let fuelForEnumerator ← `($(mkIdent ``min) 2 $initSizeIdent)
+          let fuelForEnumerator ← `($initSizeIdent:term)
           match monadSort with
           | .Enumerator =>
             -- If a checker invokes an unconstrained enumerator,
@@ -338,6 +338,7 @@ mutual
       -- i.e. check if an instance for `ArbitrarySizedSuchThat` / `EnumSizedSuchThat` with the
       -- specified `argTys` and `prop` already exists
       let (args, argTys) := List.unzip varsTys
+      -- let argTyTerms ← monadLift $ argTys.toArray.mapM constructorExprToTSyntaxTerm
       let argTyExprs := argTys.map (Option.map ToExpr.toExpr)
       let typedArgs := List.zip args argTyExprs
       let argsTuple ← mkTuple typedArgs
@@ -361,7 +362,7 @@ mutual
 end
 
 def nameAndConstructorExprToTypedVar (v : Name × Option ConstructorExpr) : Name × Option Expr :=
-  Prod.map id (ToExpr.toExpr <$> ·) v
+  Prod.map id (ToExpr.toExpr <$> .) v
 
 /-- Compiles a `ScheduleStep` to an `MExp`.
      Note that `MExp` that is returned by this function is represented
@@ -375,6 +376,8 @@ def nameAndConstructorExprToTypedVar (v : Name × Option ConstructorExpr) : Name
     - `mfuel` and `defFuel` are `MExp`s representing the current size and the initial size
       supplied to the generator/enumerator/checker we're deriving
 -/
+
+-- #eval elabType `(String)
 
 def scheduleStepToMExp (step : ScheduleStep) (defFuel : MExp) (k : MExp) (outputType : Expr) : CompileScheduleM MExp :=
   match step with

--- a/Plausible/Chamelean/MExp.lean
+++ b/Plausible/Chamelean/MExp.lean
@@ -300,8 +300,6 @@ mutual
               throwError m!"empty list of vars supplied to MBind, deriveSort = {repr deriveSort}, monadSort = {repr monadSort}, m1 = {m1}, k1 = {k1}"
             else
               mkTuple vars
-          -- We pass in `(min 2 initSize)` as the amount of fuel for the enumerator to avoid stack-overflow
-          -- See https://github.com/ngernest/chamelean/issues/40 for details
           let fuelForEnumerator ← `($initSizeIdent:term)
           match monadSort with
           | .Enumerator =>

--- a/Test.lean
+++ b/Test.lean
@@ -36,8 +36,9 @@ import Test.DeriveArbitrary.MissingNonRecursiveConstructorTest
 import Test.DeriveArbitrary.ParameterizedTypeTest
 import Test.DeriveArbitrary.MutuallyRecursiveTypeTest
 
--- Tests for instances of `Enum` for simple types
+-- Tests for instances of `Enum` for simple types and for correctness of enumerator combinators
 import Test.Enum.EnumInstancesTest
+import Test.Enum.EnumeratorSizeTest
 
 -- Tests for `deriving Enum`
 import Test.DeriveEnum.DeriveTreeEnumerator

--- a/Test/Enum/EnumeratorSizeTest.lean
+++ b/Test/Enum/EnumeratorSizeTest.lean
@@ -1,0 +1,40 @@
+import Plausible.Chamelean.DecOpt
+import Plausible.Chamelean.Enumerators
+import Plausible.Chamelean.DeriveConstrainedProducer
+import Plausible.Chamelean.EnumeratorCombinators
+import Plausible.Chamelean.DeriveChecker
+
+inductive onetrue : Nat → Prop where
+| bad1 : False → onetrue n
+| bad2 : False → onetrue n
+| good : onetrue (Nat.succ Nat.zero)
+
+inductive onetrue' : Nat → Prop where
+| bad : False → onetrue' n
+| good : onetrue' (Nat.succ Nat.zero)
+
+/-
+
+Ensures that the subenumerator derived from each constructor is used exactly once when
+combining them into the top level enumerator for an inductive family.
+
+-/
+
+#guard_msgs(drop info, drop warning) in
+#derive_enumerator (fun (n : _) => onetrue n)
+#guard_msgs(drop info, drop warning) in
+#derive_enumerator (fun (n : _) => onetrue' n)
+
+/--
+info: 1
+-/
+#guard_msgs(info) in
+#eval (List.length) <$>
+  (runSizedEnum (limit := 10) (EnumSizedSuchThat.enumSizedST (fun t => onetrue t)) 5)
+
+/--
+info: 1
+-/
+#guard_msgs(all) in
+#eval ((List.length) <$>
+  (runSizedEnum (limit := 10) (EnumSizedSuchThat.enumSizedST (fun t => onetrue' t)) 5))


### PR DESCRIPTION
Enumeration exponentially improved by only including each enumerator once when combining enumerators with enumerate. Previously there was a bug in `enumerate` which would replicate the same enumeration multiple times (exponentially many) when concatenating enumerations. Now it includes each once.

Previously, when checkers used enumerators they only considered terms enumerated up to fuel 2, due to issues with the LazyList implementation. Those were fixed with the introduction of lazy schedule enumeration, so now it is safe to consider terms from higher fuel.