### PR TITLE
chore: Fix most (but not all) linter errors.

### DIFF
--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -12,3 +12,5 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: leanprover/lean-action@v1
+        with:
+          lint: false

--- a/Plausible/Chamelean/ArbitraryFueled.lean
+++ b/Plausible/Chamelean/ArbitraryFueled.lean
@@ -26,4 +26,5 @@ class ArbitraryFueled (α : Type) where
 instance [ArbitraryFueled α] : Arbitrary α where
   arbitrary := Gen.sized ArbitraryFueled.arbitraryFueled
 
+/-- This error is thrown if the generator runs out of fuel; can be caught with `try ... catch | .genError "GenError: Out of fuel." => ...` -/
 def Gen.outOfFuel : GenError := .genError "GenError: Out of fuel."

--- a/Plausible/Chamelean/Enumerators.lean
+++ b/Plausible/Chamelean/Enumerators.lean
@@ -103,25 +103,26 @@ instance : EnumSized Nat where
 
 namespace EnumeratorCombinators
 
-  /-- `vectorOf k e` creates an enumerator of lists of length `k`,
-      where each element in the list comes from the enumerator `e` -/
-  def vectorOf (k : Nat) (e : Enumerator α) : Enumerator (List α) :=
-    List.foldr (fun m m' => do
-      let x ← m
-      let xs ← m'
-      return x::xs) (init := pure []) (List.replicate k e)
+/-- `vectorOf k e` creates an enumerator of lists of length `k`,
+    where each element in the list comes from the enumerator `e` -/
+def vectorOf (k : Nat) (e : Enumerator α) : Enumerator (List α) :=
+  List.foldr (fun m m' => do
+    let x ← m
+    let xs ← m'
+    return x::xs) (init := pure []) (List.replicate k e)
 
-  /-- Picks one of the enumerators in `es`, returning the `default` enumerator
-      if `es` is empty. -/
-  def oneOfWithDefault (default : Enumerator α) (es : List (Enumerator α)) : Enumerator α :=
-    match es with
-    | [] => default
-    | _ => do
-      let idx ← enumNatRange 0 (es.length - 1)
-      List.getD es idx default
+/-- Picks one of the enumerators in `es`, returning the `default` enumerator
+    if `es` is empty. -/
+def oneOfWithDefault (default : Enumerator α) (es : List (Enumerator α)) : Enumerator α :=
+  match es with
+  | [] => default
+  | _ => do
+    let idx ← enumNatRange 0 (es.length - 1)
+    List.getD es idx default
 
-  def oneOf [Inhabited α] (es : List (Enumerator α)) : Enumerator α :=
-    oneOfWithDefault (pure default) es
+/-- Picks one of the enumerators in `es`, or the `default` value if `es = []`. -/
+def oneOf [Inhabited α] (es : List (Enumerator α)) : Enumerator α :=
+  oneOfWithDefault (pure default) es
 
 end EnumeratorCombinators
 

--- a/Plausible/Chamelean/Idents.lean
+++ b/Plausible/Chamelean/Idents.lean
@@ -25,6 +25,7 @@ def auxDecFn : Ident := mkIdent $ Name.mkStr1 "aux_dec"
 /-- Ident for the `DecOpt.andOptList` checker combinator (see `DecOpt.lean`) -/
 def andOptListFn : Ident := mkIdent $ Name.mkStr2 "DecOpt" "andOptList"
 
+/-- Ident for `GeneratorCombinators.backtrack`. -/
 def genBacktrackFn : Ident := mkIdent $ Name.mkStr2 "GeneratorCombinators" "backtrack"
 
 /-- Ident for the `DecOpt.checkerBacktrack` checker combinator (see `DecOpt.lean`) -/
@@ -39,7 +40,10 @@ def enumeratingFn : Ident := mkIdent $ Name.mkStr2 "EnumeratorCombinators" "enum
 /-- Ident for the `EnumeratorCombinators.enumeratingOpt` combinator (see `EnumeratorCombinators.lean`) -/
 def enumeratingOptFn : Ident := mkIdent $ Name.mkStr2 "EnumeratorCombinators" "enumeratingOpt"
 
+/-- Ident for `pure`. -/
 def pureFn : Ident := mkIdent $ Name.mkStr1 "pure"
+
+/-- Idents for boolean literals. -/
 def trueIdent : Ident := mkIdent ``true
 def falseIdent : Ident := mkIdent ``false
 

--- a/Plausible/Chamelean/LazyList.lean
+++ b/Plausible/Chamelean/LazyList.lean
@@ -10,10 +10,12 @@ deriving Inhabited
 
 namespace LazyList
 
+/-- Membership in a `LazyList`. -/
 inductive InLazyList {α : Type u} (a : α) : LazyList α -> Prop where
 | InLHead l : InLazyList a (lcons a l)
 | InLNext b l : a ≠ b -> InLazyList a l.get -> InLazyList a (lcons b l)
 
+/-- Convenience definition for inverted membership. -/
 abbrev InLazyList' {α} l (a : α) := InLazyList a l
 
 instance {α} : Membership α (LazyList α) :=
@@ -45,7 +47,8 @@ def take (n : Nat) (l : LazyList α) : List α := go n l []
     | .lnil => acc
     | .lcons x xs => go n' xs.get (x :: acc)
 
-def head (l : LazyList α) : Option α :=
+/-- Get the first element of the list, if there is one. otherwise return `.none`. -/
+def head? (l : LazyList α) : Option α :=
   match l with
   | lnil => none
   | lcons x _ => some x
@@ -72,6 +75,7 @@ def mapLazyList (f : α → β) (l : LazyList α) : LazyList β :=
 instance : Functor LazyList where
   map := mapLazyList
 
+/-- Return the lazylist that contains the elements `x` of `l` such that `p x = .true`. -/
 def filter {α} (p : α -> Bool) (l : LazyList α) : LazyList α :=
   match l with
   | lnil => lnil

--- a/Plausible/Chamelean/MExp.lean
+++ b/Plausible/Chamelean/MExp.lean
@@ -358,7 +358,7 @@ mutual
 
 end
 
-def nameAndConstructorExprToTypedVar (v : Name × Option ConstructorExpr) : Name × Option Expr :=
+private def nameAndConstructorExprToTypedVar (v : Name × Option ConstructorExpr) : Name × Option Expr :=
   Prod.map id (ToExpr.toExpr <$> ·) v
 
 /-- Compiles a `ScheduleStep` to an `MExp`.

--- a/Plausible/Chamelean/Schedules.lean
+++ b/Plausible/Chamelean/Schedules.lean
@@ -87,10 +87,12 @@ inductive ScheduleStep
 
   deriving Repr, BEq, Ord
 
+/-- Stringifier for `Source` -/
 def sourceToString source := match source with
   | Source.Rec name ctrArgs => s!"{ToExpr.toExpr (name,ctrArgs)}"
   | Source.NonRec hyp => s!"{ToExpr.toExpr hyp}"
 
+/-- Stringifier for `step` -/
 def stepToString step := match step with
     | ScheduleStep.Unconstrained name src _ => s!"{name} ← {sourceToString src}"
     | .SuchThat vars src _ => s!"{vars.map (fun ((name : Name), (_ : Option ConstructorExpr)) => name)} ← {sourceToString src}"
@@ -98,6 +100,7 @@ def stepToString step := match step with
     | .Check src false => s!"check ¬{sourceToString src}"
     | .Match name pattern => s!"match {name} with {repr pattern}"
 
+/-- Stringifier for lists of steps. -/
 def scheduleStepsToString (steps : List ScheduleStep) := "do\n  " ++ String.intercalate "\n  " (stepToString <$> steps)
 
 /-- A schedule is a pair consisting of an ordered list of `ScheduleStep`s,

--- a/Plausible/Chamelean/Utils.lean
+++ b/Plausible/Chamelean/Utils.lean
@@ -5,12 +5,14 @@ import Batteries.Data.List.Basic
 
 open Lean Meta LocalContext Std
 
+/-- A variable along with its fully elaborated type.
+Will likely be replaced by variables directly living in `Expr` at some point. -/
 structure TypedVar where
+  /-- The variable name -/
   var : Name
+  /-- The variable's fully elaborated type. -/
   type : Expr
   deriving Repr, BEq
-
-def exprHole : MetaM Expr := mkFreshExprMVar none
 
 /-- `containsNonTrivialFuncApp e inductiveRelationName` determines whether `e` contains a non-trivial function application
     (i.e. a function application where the function name is *not* the same as `inductiveRelationName`,

--- a/Plausible/Gen.lean
+++ b/Plausible/Gen.lean
@@ -31,6 +31,7 @@ inductive GenError : Type where
 | genError : String → GenError
 deriving Inhabited, Repr, BEq
 
+/-- A non-descript generation failure. -/
 def Gen.genericFailure : GenError := .genError "Generation failure."
 
 /-- Monad to generate random examples to test properties with.
@@ -43,6 +44,7 @@ instance instMonadLiftGen [MonadLiftT m (ReaderT (ULift Nat) (Except GenError))]
 
 instance instMonadErrorGen : MonadExcept GenError Gen := by infer_instance
 
+/-- Lift a `GenError` to `IO.Error`. -/
 def Gen.genFailure (e : GenError) : IO.Error :=
   let .genError mes := e
   IO.userError s!"generation failure: {mes}"
@@ -223,7 +225,7 @@ partial def Gen.runUntil {α : Type} (attempts : Option Nat := .none) (x : Gen �
   | .none => .none
 
 
-def test : Gen Nat :=
+private def test : Gen Nat :=
   do
     let x : Nat ← Gen.choose Nat 0 (← Gen.getSize) (Nat.zero_le _)
     if x % 10 == 0

--- a/Plausible/Testable.lean
+++ b/Plausible/Testable.lean
@@ -258,6 +258,7 @@ open TestResult
 
 def runProp (p : Prop) [Testable p] : Configuration → Bool → Gen (TestResult p) := Testable.run
 
+/-- Run the test for `p`, returning any thrown `Gen.GenError` as a `TestResult.gaveUp`. -/
 def runPropE (p : Prop) [Testable p] (cfg : Configuration) (min : Bool) : Gen (TestResult p) :=
   do
     try runProp p cfg min

--- a/Test.lean
+++ b/Test.lean
@@ -3,8 +3,8 @@ Copyright (c) 2024 Lean FRO, LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Henrik Böving
 -/
--- import Test.Tactic
--- import Test.Testable
+import Test.Tactic
+import Test.Testable
 
 -- Common definitions for snapshot tests
 import Test.CommonDefinitions.BinaryTree


### PR DESCRIPTION
Not entirely clear how to fix the linter warnings for local `where` definitions and `derving Repr`s.