### PR TITLE
feat: Major pruning of equivalent schedules in enumeration; Support for Literals; Bugfix

### DIFF
--- a/Plausible/Chamelean/DeriveConstrainedProducer.lean
+++ b/Plausible/Chamelean/DeriveConstrainedProducer.lean
@@ -156,13 +156,7 @@ partial def convertExprToRangeInCurrentContext (e : Expr) : UnifyM Range := do
     else
       match e with
       | .const u _ => return (.Unknown u)
-      | .lit literal =>
-        -- Nat / String literals correspond to a `Range` that is a nullary constructor
-        let name :=
-          match literal with
-          | .natVal n => Name.mkStr1 (toString n)
-          | .strVal s => Name.mkStr1 s
-        return .Ctor name []
+      | .lit literal => return .Lit literal
       | _ => throwError m!"Cannot convert expression {e} to Range"
 
 /-- Converts a hypothesis (reprented as a `TSyntax term`) to a `Range` -/
@@ -190,6 +184,7 @@ def convertPatternToTerm (pattern : Pattern) : MetaM (TSyntax `term) :=
     let ctorIdent := mkIdent ctorName
     let argSyntaxes ← args.mapM convertPatternToTerm
     argSyntaxes.foldlM (fun acc arg => `($acc $arg)) ctorIdent
+  | .LitPattern l => mkLiteral l
 
 
 /-- Converts a `Range` to a `ConstructorExpr`
@@ -200,6 +195,8 @@ partial def convertRangeToConstructorExpr (r : Range) : UnifyM ConstructorExpr :
   | .Ctor ctorName args => do
     let updatedArgs ← args.mapM convertRangeToConstructorExpr
     return (.Ctor ctorName updatedArgs)
+  | .Lit l =>
+    return .Lit l
   | _ => throwError m!"Unable to convert {r} to a constructor expression"
 
 /-- Converts a `Range` that is either an `Unknown` or `Ctor` to
@@ -255,7 +252,9 @@ def rewriteFunctionCallsInConclusion (hypotheses : Array Expr) (conclusion : Exp
   -- Find all sub-terms which are non-trivial function applications
   let funcAppExprs ← conclusion.foldlM (init := []) (fun acc subExpr => do
     if (← containsNonTrivialFuncApp subExpr inductiveRelationName)
-      then pure (subExpr :: acc)
+      then
+      logWarning m!"{repr subExpr} has a function call in it"
+      pure (subExpr :: acc)
     else
       pure acc)
 
@@ -323,7 +322,7 @@ def rewriteFunctionCallsInConclusion (hypotheses : Array Expr) (conclusion : Exp
 def getScheduleForInductiveRelationConstructor
   (inductiveName : Name) (ctorName : Name) (inputNames : List Name)
   (deriveSort : DeriveSort) (outputNameTypeOption : Option (Name × Expr)) (unknownsArray : Array Unknown) : UnifyM Schedule := do
-  logWarning m!"CALL MADE: {inductiveName} {ctorName} {inputNames} {unknownsArray}"
+  trace[plausible.deriving.arbitrary] "Schedule requested for inductive {inductiveName}'s constructor, {ctorName} with inputs: {inputNames} and outputs: {unknownsArray}"
 
   let ctorInfo ← getConstInfoCtor ctorName
   let ctorType := ctorInfo.type
@@ -478,16 +477,16 @@ def getScheduleForInductiveRelationConstructor
       let countChecks (schd : List ScheduleStep) : Nat :=
         schd.foldl (fun acc step => match step with | .Check _ _ => acc + 1 | _ => acc) 0
 
-      let smallestOfFirst100 ← List.foldlM (fun (shortest,minChecks,minLen) schdM => do
+      let smallestOfFirst100 ← List.foldlM (fun (shortest,minChecks,minLen, countSeen) schdM => do
         let schd ← schdM
         let checkCount := countChecks schd
         let len := schd.length
         if checkCount < minChecks || (checkCount == minChecks && len < minLen) then
-          pure (schd, checkCount, len)
-        else pure (shortest, minChecks, minLen)) (fstSchd, countChecks fstSchd, fstSchd.length)
-                    $ LazyList.take 100 rest.get
+          pure (schd, checkCount, len, countSeen + 1)
+        else pure (shortest, minChecks, minLen, countSeen + 1)) (fstSchd, countChecks fstSchd, fstSchd.length, 1)
+                    $ LazyList.take 100000 rest.get
 
-      logInfo m!"Chosen Schedule: {scheduleStepsToString smallestOfFirst100.1} \n Checks: {smallestOfFirst100.2}"
+      logInfo m!"Chosen Schedule: {scheduleStepsToString smallestOfFirst100.1} \nChecks: {smallestOfFirst100.2} \nSchedules Considered: {smallestOfFirst100.2.2.2}"
 
       -- A *naive* schedule is the first schedule contained in `possibleSchedules`
       let originalNaiveScheduleM := smallestOfFirst100.1

--- a/Plausible/Chamelean/DeriveConstrainedProducer.lean
+++ b/Plausible/Chamelean/DeriveConstrainedProducer.lean
@@ -253,7 +253,7 @@ def rewriteFunctionCallsInConclusion (hypotheses : Array Expr) (conclusion : Exp
   let funcAppExprs ← conclusion.foldlM (init := []) (fun acc subExpr => do
     if (← containsNonTrivialFuncApp subExpr inductiveRelationName)
       then
-      logWarning m!"{repr subExpr} has a function call in it"
+      trace[plausible.deriving.arbitrary]  m!"{repr subExpr} has a function call in it"
       pure (subExpr :: acc)
     else
       pure acc)
@@ -633,7 +633,7 @@ def deriveConstrainedProducer (outputVar : Ident) (outputTypeSyntax : TSyntax `t
 
       if (not requiredInstances.isEmpty) then
         let deduplicatedInstances := List.eraseDups requiredInstances.toList
-        logWarning m!"Required typeclass instances (please derive these first if they aren't already defined):\n{deduplicatedInstances}"
+        trace[plausible.deriving.arbitrary]  m!"Required typeclass instances (please derive these first if they aren't already defined):\n{deduplicatedInstances}"
 
       -- Collect all the base / inductive producers into two Lean list terms
       -- Base producers are invoked when `size = 0`, inductive producers are invoked when `size > 0`

--- a/Plausible/Chamelean/DeriveConstrainedProducer.lean
+++ b/Plausible/Chamelean/DeriveConstrainedProducer.lean
@@ -477,28 +477,33 @@ def getScheduleForInductiveRelationConstructor
       let countChecks (schd : List ScheduleStep) : Nat :=
         schd.foldl (fun acc step => match step with | .Check _ _ => acc + 1 | _ => acc) 0
 
-      let smallestOfFirst100 ← List.foldlM (fun (shortest,minChecks,minLen, countSeen) schdM => do
+      let mut minChecks := countChecks fstSchd
+      let mut countSeen  := 1
+      let mut minLen     := fstSchd.length
+      let mut bestSchedule   := fstSchd
+
+      let prefixSize := 100000
+
+      for schdM in LazyList.take prefixSize rest.get do
         let schd ← schdM
         let checkCount := countChecks schd
+        countSeen := countSeen + 1
         let len := schd.length
         if checkCount < minChecks || (checkCount == minChecks && len < minLen) then
-          pure (schd, checkCount, len, countSeen + 1)
-        else pure (shortest, minChecks, minLen, countSeen + 1)) (fstSchd, countChecks fstSchd, fstSchd.length, 1)
-                    $ LazyList.take 100000 rest.get
+          bestSchedule := schd
+          minChecks := checkCount
+          minLen := len
 
-      logInfo m!"Chosen Schedule: {scheduleStepsToString smallestOfFirst100.1} \nChecks: {smallestOfFirst100.2} \nSchedules Considered: {smallestOfFirst100.2.2.2}"
+      trace[plausible.deriving.arbitrary] m!"Chosen Schedule: {scheduleStepsToString bestSchedule} \nChecks & Length: {(minChecks, minLen)} \nSchedules Considered: {repr countSeen}"
 
-      -- A *naive* schedule is the first schedule contained in `possibleSchedules`
-      let originalNaiveScheduleM := smallestOfFirst100.1
-      -- Update the naive schedule with the result of unification
-      let updatedNaiveScheduleUnify ← updateScheduleSteps originalNaiveScheduleM
-      let updatedNaiveSchedule := updatedNaiveScheduleUnify
+      -- Update the best schedule with the result of unification
+      let updatedBestSchedule ← updateScheduleSteps bestSchedule
       let finalState ← get
 
       -- Takes the `patterns` and `equalities` fields from `UnifyState` (created after
       -- the conclusion of a constructor has been unified with the top-level arguments to the inductive relation),
       -- convert them to the appropriate `ScheduleStep`s, and prepends them to the `naiveSchedule`
-      pure $ addConclusionPatternsAndEqualitiesToSchedule finalState.patterns finalState.equalities (updatedNaiveSchedule, scheduleSort))
+      pure $ addConclusionPatternsAndEqualitiesToSchedule finalState.patterns finalState.equalities (updatedBestSchedule, scheduleSort))
   )
 
 

--- a/Plausible/Chamelean/DeriveSchedules.lean
+++ b/Plausible/Chamelean/DeriveSchedules.lean
@@ -5,6 +5,7 @@ import Plausible.Chamelean.Schedules
 import Plausible.Chamelean.UnificationMonad
 import Plausible.Chamelean.MakeConstrainedProducerInstance
 import Plausible.Chamelean.LazyList
+import Lean.Util.SCC
 
 
 open Lean Meta
@@ -35,6 +36,7 @@ def variablesInConstructorExpr (ctorExpr : ConstructorExpr) : List Name :=
   match ctorExpr with
   | .Unknown u => [u]
   | .Ctor _ args | .FuncApp _ args => args.flatMap variablesInConstructorExpr
+  | .Lit _ => []
 
 /-- Given a hypothesis `hyp`, along with `binding` (a list of variables that we are binding with a call to a generator), plus `recCall` (a pair contianing the name of the inductive and a list of output argument indices),
     this function checks whether the generator we're using is recursive.
@@ -152,6 +154,7 @@ partial def outputsNotConstrainedByFunctionApplication (hyp : HypothesisExpr) (o
         | .Unknown u => return (b && u ∈ outputVars)
         | .Ctor _ args => args.anyM (check b)
         | .FuncApp _ args => args.anyM (check true)
+        | .Lit _ => return false
 
 private inductive OptionallyTypedVar where
 | TVar : TypedVar -> OptionallyTypedVar
@@ -215,7 +218,11 @@ def handleConstrainedOutputs (hyp : HypothesisExpr) (outputVars : List TypedVar)
       | none  =>
         pure (none, arg, none)
     | .FuncApp _ _ =>
-      pure (none, arg, none))
+      pure (none, arg, none)
+    | .Lit _ =>
+      pure (none, arg, none)
+
+      )
 
   return (patternMatches.filterMap id, (ctorName, args'), newOutputs.filterMap id)
 
@@ -251,7 +258,7 @@ private def subsetsAndComplements {α} (as : List α) : LazyList (List α × Lis
   | [] => pure ([],[])
   | a :: as' => do
     let (subset,comp) ← subsetsAndComplements as'
-    .lcons (subset,a :: comp) ⟨ fun _ => .lcons (a :: subset, comp) ⟨fun _ => .lnil⟩⟩
+    .lcons (a :: subset,comp) ⟨ fun _ => .lcons (subset,a :: comp) ⟨fun _ => .lnil⟩⟩
 
 /- Unused utility function for future if we wish to prune selections of hypotheses by some predicate -/
 private def subsetsAndComplementsSuchThat {α} (p : α -> Bool) (as : List α) : LazyList (List α × List α) :=
@@ -302,13 +309,14 @@ private partial def containsFunctionCall (ctrExpr : ConstructorExpr) : Bool :=
   | .Unknown _ => false
   | .Ctor _ args => List.any args (fun x => containsFunctionCall x)
   | .FuncApp _ _ => true
+  | .Lit _ => false
 
 private def constructHypothesis (hyp : HypothesisExpr × List (List Name)) : HypothesisExpr × List (List Name) × List Name :=
   let repeatedNames := collectRepeatedNames hyp.snd
   let hypIndices := List.zip hyp.fst.snd hyp.snd
   let (mustBind, allSafe) := hypIndices.partition (fun (ctrExpr, vars) =>
     containsFunctionCall ctrExpr || (vars.any (List.contains repeatedNames)))
-  (hyp.fst, allSafe.map (fun x => x.snd), mustBind.flatMap (fun x => x.snd))
+  (hyp.fst, allSafe.map (fun x => x.snd), (List.eraseDups mustBind).flatMap (fun x => x.snd))
 
 private def needs_checking {α v} [BEq v] (env : List v) (a_vars : α × List (List v) × List v) : Bool :=
   let (_, potentialIndices, alwaysBound) := a_vars
@@ -324,6 +332,34 @@ private def prune_empties {α v} (schd : List (PreScheduleStep α v)) : List (Pr
       | .InstVars [] => l
       | .Produce [] h => .Checks [h] :: l
       | _ => pss :: l
+
+def computeSCC {v a} [DecidableEq v] (hypotheses : List (a × List v)) : List (List (a × List v)) :=
+  let indices := List.range hypotheses.length
+  let successors := fun i =>
+    indices.filter fun j =>
+      i ≠ j &&
+      match hypotheses[i]?, hypotheses[j]? with
+      | some (_, vars), some (_, vars') => vars.any (· ∈ vars')
+      | _, _ => false
+  let sccIndices := Lean.SCC.scc indices successors
+  sccIndices.map fun component =>
+    component.filterMap (fun i => hypotheses[i]?)
+
+#guard_msgs(error, drop info) in
+#eval computeSCC [("H", [1,2,3]), ("I", [4,5]), ("J",[5,1])]
+
+-- Example: Two connected components {a,b,c} & {a} vs {d} & {d,e}
+#guard_msgs(error, drop info) in
+#eval computeSCC [("H1", ["a", "b", "c"]), ("H2", ["a"]), ("H3", ["d"]), ("H4", ["d", "e"])]
+
+-- Example: All connected through shared variables
+#guard_msgs(error, drop info) in
+#eval computeSCC [("H1", ["a"]), ("H2", ["a", "b"]), ("H3", ["b", "c"]), ("H4", ["c"])]
+
+-- Example: No connections (all separate)
+#guard_msgs(error, drop info) in
+#eval computeSCC [("H1", ["a"]), ("H2", ["b"]), ("H3", ["c"])]
+
 
   /- For each permutation, for each of its hypotheses, select which of its
   unbound variables should be instantiated to satisfy it.
@@ -473,6 +509,59 @@ private partial def enum_schedules {α v} [BEq v] (vars : List v) (hyps : List (
 #guard_msgs(error, drop info) in
 #eval (enum_schedules [`n, `m] [(`n_le_m, [], [`n, `m])] [`n,`m]).take 5
 
+partial def enum_schedules' {α v} [BEq v] (vars : List v) (hypComps : List (List (α × List (List v) × List v))) (env : List v)
+  : LazyList (List (PreScheduleStep α v)) :=
+  match hypComps with
+  | [] => pure (prune_empties [.InstVars $ vars.removeAll env])
+  | [] :: hypComps' => enum_schedules' vars hypComps' env
+  | hyps :: hypComps' => do
+    let ⟨ (hyp, potential_output_indices, always_bound_variables),hyps' ⟩ ← select hyps
+    let (some_bound_output_indices, all_unbound_output_indices) := List.partition (fun l => List.any l (List.contains env) || l.isEmpty) potential_output_indices
+    let (out,bound) ← subsetsAndComplements all_unbound_output_indices
+    if out.length > 1 then .lnil else
+    let bound_vars := bound.flatten ++ (always_bound_variables ++ some_bound_output_indices.flatten).filter (not ∘ List.contains env)
+    let env' := bound_vars ++ env
+    let (prechecks,to_be_satisfied) := List.partition (needs_checking env') hyps'
+    let out_vars := out.flatten
+    let env'' := out_vars ++ env'
+    let (postchecks,to_be_satisfied') := List.partition (needs_checking env'') to_be_satisfied
+    LazyList.mapLazyList (fun l => prune_empties [.InstVars bound_vars
+                              , .Checks (Prod.fst <$> prechecks)
+                              , .Produce out_vars hyp
+                              , .Checks (Prod.fst <$> postchecks)
+                              ]
+                              ++ l) (enum_schedules' vars (to_be_satisfied' :: hypComps') env'')
+
+#guard_msgs(error, drop info) in
+#eval (enum_schedules' [1,2,3,4] [[("A",[[1,2,3],[4]],[])], [("B",[[4]],[])]] []).take 15
+
+-- Two separate SCCs: {H1,H2} share 'a', {H3,H4} share 'd'
+#guard_msgs(error, drop info) in
+#eval (enum_schedules' ["a","b","c","d","e"] [[("H1",[["a"],["b"],["c"]],[]), ("H2",[["a"]],[])], [("H3",[["d"]],[]), ("H4",[["d"],["e"]],[])]] []).take 100
+
+-- Three SCCs: connected chain, isolated, pair
+#guard_msgs(error, drop info) in
+#eval (enum_schedules' [1,2,3,4,5,6] [[("A",[[1],[2]],[]), ("B",[[2],[3]],[]), ("C",[[3]],[])], [("D",[[4]],[])], [("E",[[5]],[]), ("F",[[5],[6]],[])]] []).take 100
+
+-- Multiple single-node SCCs
+#guard_msgs(error, drop info) in
+#eval (enum_schedules' [1,2,3] [[("X",[[1]],[])], [("Y",[[2]],[])], [("Z",[[3]],[])]] []).take 2
+
+-- Comparison: enum_schedules vs enum_schedules' - total schedule counts
+-- Example 1: Two separate SCCs should reduce schedules significantly
+#guard_msgs(error, drop info) in
+#eval (enum_schedules ["a","b","c","d"] [("H1",[["a"],["b"]],[]), ("H2",[["a"]],[]), ("H3",[["c"],["d"]],[]), ("H4",[["c"]],[])] []).length
+
+#guard_msgs(error, drop info) in
+#eval (enum_schedules' ["a","b","c","d"] [[("H1",[["a"],["b"]],[]), ("H2",[["a"]],[])], [("H3",[["c"],["d"]],[]), ("H4",[["c"]],[])]] []).length
+
+-- Example 2: Single SCC should have same count
+#guard_msgs(error, drop info) in
+#eval (enum_schedules [1,2,3] [("A",[[1],[2]],[]), ("B",[[2],[3]],[])] []).length
+
+#guard_msgs(error, drop info) in
+#eval (enum_schedules' [1,2,3] [[("A",[[1],[2]],[]), ("B",[[2],[3]],[])]] []).length
+
 -- Determine the right name for the recursive function in the producer
 private def recursiveFunctionName (deriveSort : DeriveSort) : Name :=
   match deriveSort with
@@ -574,12 +663,33 @@ def possibleSchedules (vars : List TypedVar) (hypotheses : List HypothesisExpr) 
   let remainingVars := List.filter (fun v => not $ fixedVars.contains v) varNames
   let (newCheckedIdxs, newCheckedHyps) := List.unzip $ (collectCheckSteps scheduleEnv fixedVars [])
   let remainingSortedHypotheses := filterWithIndex (fun i _ => i ∉ newCheckedIdxs) sortedHypotheses
+  let connectedHypotheses := (computeSCC (remainingSortedHypotheses.map (fun (h,vars) => ((h,vars),vars.flatten)))).map (List.map fun ((h,vars),_) => constructHypothesis (h,vars))
   let firstChecks := List.reverse $ (ScheduleStep.Check . true) <$> newCheckedHyps
-  let lazyPreSchedules : LazyList (List (PreScheduleStep HypothesisExpr Name)) := enum_schedules remainingVars (remainingSortedHypotheses.map constructHypothesis) fixedVars
+  let lazyPreSchedules : LazyList (List (PreScheduleStep HypothesisExpr Name)) := enum_schedules' remainingVars connectedHypotheses fixedVars
   let nameTypeMap := List.foldl (fun m ⟨name,ty⟩ => NameMap.insert m name ty) ∅ vars
   let typedPreSchedules : LazyList (List (PreScheduleStep HypothesisExpr TypedVar)) := lazyPreSchedules.mapLazyList (List.map (typePreScheduleStep nameTypeMap))
   let lazySchedules := typedPreSchedules.mapLazyList ((ReaderT.run . scheduleEnv) ∘ ((firstChecks ++ .) <$> .) ∘ List.flatMapM preScheduleStepToScheduleStep)
   lazySchedules
+
+-- Complex example with many hypotheses (ValidCtrlAl constructor)
+#guard_msgs(error, drop info) in
+#eval computeSCC [("ValidAluHeader", ["header"]), ("ValidEvents", ["events"]), ("ValidDtype64", ["dtype"]), ("ValidAluOp", ["op"]), ("ValidRegisterRead", ["src0_lo"]), ("ValidRegisterRead", ["src0_hi"]), ("ValidRegisterRead", ["src1_lo"]), ("ValidRegisterRead", ["src1_hi"]), ("ValidRegisterWrite", ["dst_lo"]), ("ValidRegisterWrite", ["dst_hi"]), ("CtrlAlValidRegisterOpCombination", ["op", "dtype"]), ("CtrlAlValidDtype", ["dtype"])]
+
+#guard_msgs(error, drop info) in
+#eval (enum_schedules ["header", "events", "dtype", "op", "src0_lo", "src0_hi", "src1_lo", "src1_hi", "dst_lo", "dst_hi"] [("ValidAluHeader", [["header"]],[]), ("ValidEvents", [["events"]],[]), ("ValidDtype64", [["dtype"]],[]), ("ValidAluOp", [["op"]],[]), ("ValidRegisterRead1", [["src0_lo"]],[]), ("ValidRegisterRead2", [["src0_hi"]],[]), ("ValidRegisterRead3", [["src1_lo"]],[]), ("ValidRegisterRead4", [["src1_hi"]],[]), ("ValidRegisterWrite1", [["dst_lo"]],[]), ("ValidRegisterWrite2", [["dst_hi"]],[]), ("CtrlAlValidRegisterOpCombination", [["op"], ["dtype"]],[]), ("CtrlAlValidDtype", [["dtype"]],[])] []).take 3
+
+#guard_msgs(error, drop info) in
+#eval (enum_schedules' ["header", "events", "dtype", "op", "src0_lo", "src0_hi", "src1_lo", "src1_hi", "dst_lo", "dst_hi", "datasrc", "imm"]
+  [[("ValidAluHeader", [["header"]],[])],
+   [("ValidEvents", [["events"]],[])],
+   [("ValidDtype64", [["dtype"],[],[],[]],[]), ("CtrlAlValidRegisterOpCombination", [["op"], ["dtype"]],[]), ("ValidAluOp", [["op"]],[]), ("CtrlAlValidDtype", [["dtype"]],[])],
+   [("ValidRegisterRead1", [["src0_lo"]],[])],
+   [("ValidRegisterRead2", [["src0_hi"]],[])],
+   [("ValidRegisterRead3", [["src1_lo"]],[])],
+   [("ValidRegisterRead4", [["src1_hi"]],[])],
+   [("ValidRegisterWrite1", [["dst_lo"]],[])],
+   [("ValidRegisterWrite2", [["dst_hi"]],[])]] [
+   ]).length
 
 private def tryTypedSchedules (vars : List (Name × Expr)) hyps := do
   let lazyPreSchedules : LazyList (List (PreScheduleStep Name Name)) := enum_schedules (List.map (fun ((name, _typ) : Name × Expr) => name) vars) hyps []

--- a/Plausible/Chamelean/DeriveSchedules.lean
+++ b/Plausible/Chamelean/DeriveSchedules.lean
@@ -345,93 +345,99 @@ def computeSCC {v a} [DecidableEq v] (hypotheses : List (a × List v)) : List (L
   sccIndices.map fun component =>
     component.filterMap (fun i => hypotheses[i]?)
 
-#guard_msgs(error, drop info) in
+-- Two connected components {H} and {I,J}, as the latter share the variable 5
+/--info: [[("H", [1, 2, 3]), ("J", [5, 1]), ("I", [4, 5])]]-/
+#guard_msgs(all) in
 #eval computeSCC [("H", [1,2,3]), ("I", [4,5]), ("J",[5,1])]
 
--- Example: Two connected components {a,b,c} & {a} vs {d} & {d,e}
-#guard_msgs(error, drop info) in
+-- Example: Two connected components H1{a,b,c} & H2{a} vs H3{d} & H4{d,e}; the first two share a, the latter two share d
+/--info: [[("H1", ["a", "b", "c"]), ("H2", ["a"])], [("H3", ["d"]), ("H4", ["d", "e"])]]-/
+#guard_msgs(all) in
 #eval computeSCC [("H1", ["a", "b", "c"]), ("H2", ["a"]), ("H3", ["d"]), ("H4", ["d", "e"])]
 
--- Example: All connected through shared variables
-#guard_msgs(error, drop info) in
+-- Example: Transitive dependencies make one big connected component.
+/--info: [[("H1", ["a"]), ("H2", ["a", "b"]), ("H3", ["b", "c"]), ("H4", ["c"])]]-/
+#guard_msgs(all) in
 #eval computeSCC [("H1", ["a"]), ("H2", ["a", "b"]), ("H3", ["b", "c"]), ("H4", ["c"])]
 
--- Example: No connections (all separate)
-#guard_msgs(error, drop info) in
+-- Example: No overlap so all hypotheses are singleton components.
+/--info: [[("H1", ["a"])], [("H2", ["b"])], [("H3", ["c"])]]-/
+#guard_msgs(all) in
 #eval computeSCC [("H1", ["a"]), ("H2", ["b"]), ("H3", ["c"])]
 
 
-  /- For each permutation, for each of its hypotheses, select which of its
-  unbound variables should be instantiated to satisfy it.
-  Not all unbound variables are able to be instantiated by a hypothesis,
-  so we must filter out those unbound mentioned in the hypothesis which
-  are arguments to a function (1) and those which are under a constructor
-  that contains a bound or invalid unbound variable (2) and those that
-  appear nonlinearly (as they would require an unlikely equality check)(3).
-  Here is an encompassing example:
-  `H (C a (f b)) c (C₃ c) d (C₃ (C₂ e) C₄)`
-  We can't instantiate `b` because it is under a function (1),
-   `a` because it is under a constructor with an invalid variable `b` (2),
-   `c` because it appears nonlinearly
-  We *can* instantiate `d` and `e` because they satisfy all three conditions
-  Note that despite e being stored under several constructors, there are no
-  bound or invalid variables mixed in, so we can generate H's 5th argument
-  and pattern match the result against `(C₃ (C₂ x) C₄)` and if it matches,
-  `e` to the value `x`.
+/- For each permutation, for each of its hypotheses, select which of its
+unbound variables should be instantiated to satisfy it.
+Not all unbound variables are able to be instantiated by a hypothesis,
+so we must filter out those unbound mentioned in the hypothesis which
+are arguments to a function (1) and those which are under a constructor
+that contains a bound or invalid unbound variable (2) and those that
+appear nonlinearly (as they would require an unlikely equality check)(3).
+Here is an encompassing example:
+`H (C a (f b)) c (C₃ c) d (C₃ (C₂ e) C₄)`
+We can't instantiate `b` because it is under a function (1),
+  `a` because it is under a constructor with an invalid variable `b` (2),
+  `c` because it appears nonlinearly
+We *can* instantiate `d` and `e` because they satisfy all three conditions
+Note that despite e being stored under several constructors, there are no
+bound or invalid variables mixed in, so we can generate H's 5th argument
+and pattern match the result against `(C₃ (C₂ x) C₄)` and if it matches,
+`e` to the value `x`.
 
-  The remainder of its unbound variables should be instantiated according
-  to their type unconstrained by a hypothesis. These unconstrained instantiations
-  should happen before the constrained instantiation. For each `2^|unbound ∩ valid|`
-  choice, we prepend the unconstrained instantiations behind the constrained one
-  and lazily cons that version of the schedule to our list.
+The remainder of its unbound variables should be instantiated according
+to their type unconstrained by a hypothesis. These unconstrained instantiations
+should happen before the constrained instantiation. For each `2^|unbound ∩ valid|`
+choice, we prepend the unconstrained instantiations behind the constrained one
+and lazily cons that version of the schedule to our list.
 
-  Finally, we fold through the list, tracking the set of variables bound, as soon
-  as a constraint has had all its variables bound, a check for it
-  should be inserted at that point in the schedule. Finally, return
-  the schedules. -/
+Finally, we fold through the list, tracking the set of variables bound, as soon
+as a constraint has had all its variables bound, a check for it
+should be inserted at that point in the schedule. Finally, return
+the schedules. -/
 
-/- Depth-first enumeration of all possible schedules.
+/-
+  Depth-first enumeration of all possible schedules.
 
-    The list of possible schedules boils down to taking a permutation of list of hypotheses -- what this function
-    does is it comes up with the list of possible permutations of hypotheses.
+  The list of possible schedules boils down to taking a permutation of list of hypotheses -- what this function
+  does is it comes up with the list of possible permutations of hypotheses.
 
-    For `TyApp` in the STLC example, here are the possible permutations (output is e, the unbound vars are {e1, e2, t1}):
+  For `TyApp` in the STLC example, here are the possible permutations (output is e, the unbound vars are {e1, e2, t1}):
 
-    (a.) `[typing Γ e1 (TFun 𝜏1 𝜏2), typing Γ e2 𝜏1]`
-    (b.) `[typing Γ e2 𝜏1, typing Γ e1 (TFun 𝜏1 𝜏2)]`
+  (a.) `[typing Γ e1 (TFun 𝜏1 𝜏2), typing Γ e2 𝜏1]`
+  (b.) `[typing Γ e2 𝜏1, typing Γ e1 (TFun 𝜏1 𝜏2)]`
 
-    We first discuss permutation (a).
+  We first discuss permutation (a).
 
-    For permutation (a), `t1` and `e1` are unbound, so we're generate the max no. of variables possible
-      * `e1` is in an outputtable position (since its not under a constructor)
-      * `t1` is *not* in an ouputtable position (since `t1` is under the `TFun` constructor, `type` is an input mode, and `t2` is also an input mode)
-      * This means `t1` has to be generated first arbitrarily
+  For permutation (a), `t1` and `e1` are unbound, so we're generate the max no. of variables possible
+    * `e1` is in an outputtable position (since its not under a constructor)
+    * `t1` is *not* in an ouputtable position (since `t1` is under the `TFun` constructor, `type` is an input mode, and `t2` is also an input mode)
+    * This means `t1` has to be generated first arbitrarily
 
-    We have elaborated this step to:
-    ```lean
-      t1 ← type                      -- (this uses the `Arbitrary` instance for [type])
-      e1 ← typing Γ ? (TFun t1 t2)    -- (this desugars to `arbitraryST (fun e1 => typing Γ e1 (TFun t1 t2))` )
-    ```
+  We have elaborated this step to:
+  ```lean
+    t1 ← type                      -- (this uses the `Arbitrary` instance for [type])
+    e1 ← typing Γ ? (TFun t1 t2)    -- (this desugars to `arbitraryST (fun e1 => typing Γ e1 (TFun t1 t2))` )
+  ```
 
-    Now that we have generated `t1` and `e1`, the next hypothesis is `typing Γ e2 𝜏1`
-    * `e2` is the only variable that's unbound
-    * Thus, our only option is to do:
-    ```lean
-      e2 ← typing Γ ? t1
-    ```
+  Now that we have generated `t1` and `e1`, the next hypothesis is `typing Γ e2 𝜏1`
+  * `e2` is the only variable that's unbound
+  * Thus, our only option is to do:
+  ```lean
+    e2 ← typing Γ ? t1
+  ```
 
-    + For permutation (b), the first thing we do is check what are the unbound (not generated & not fixed by inputs)
-      variables that are constrained by the first hypothesis `typing Γ e2 𝜏1`
-      * `e2` is unbound & can be output (since its in the output mode & not generated yet)
-      * `t1` can also be output since its not been generated yet & not under a constructor
-        * `Γ` is fixed already (bound) b/c its a top-level argument (input) to `aux_arb`
-      * Here we have 3 possible choices:
-        1. Arbitrary [t1], ArbitrarySuchThat [e2]
-        2. Arbitrary [e2], ArbitrarySuchThat [t1]
-        3. ArbitrarySuchThat [e2, t1]
+  + For permutation (b), the first thing we do is check what are the unbound (not generated & not fixed by inputs)
+    variables that are constrained by the first hypothesis `typing Γ e2 𝜏1`
+    * `e2` is unbound & can be output (since its in the output mode & not generated yet)
+    * `t1` can also be output since its not been generated yet & not under a constructor
+      * `Γ` is fixed already (bound) b/c its a top-level argument (input) to `aux_arb`
+    * Here we have 3 possible choices:
+      1. Arbitrary [t1], ArbitrarySuchThat [e2]
+      2. Arbitrary [e2], ArbitrarySuchThat [t1]
+      3. ArbitrarySuchThat [e2, t1]
 
-      * For each choice, we can then elaborate the next `ScheduleStep` in our hypothesis permutation (i.e. `typing Γ e1 (TFun 𝜏1 𝜏2)`)
-      + Rest of the logic for dealing with permutation (b) is similar to as the 1st permutation
+    * For each choice, we can then elaborate the next `ScheduleStep` in our hypothesis permutation (i.e. `typing Γ e1 (TFun 𝜏1 𝜏2)`)
+    + Rest of the logic for dealing with permutation (b) is similar to as the 1st permutation
 -/
 
 /- Variables in third elt of hyp should be disjoint from flatten of snd elt
@@ -441,9 +447,9 @@ def computeSCC {v a} [DecidableEq v] (hypotheses : List (a × List v)) : List (L
    variables.
 
    The snd and third elements combined should equal the set vars(hyp.fst)
- -/
+-/
 
-private partial def enum_schedules {α v} [BEq v] (vars : List v) (hyps : List (α × List (List v) × List v)) (env : List v)
+private partial def enumSchedules {α v} [BEq v] (vars : List v) (hyps : List (α × List (List v) × List v)) (env : List v)
   : LazyList (List (PreScheduleStep α v)) :=
   match hyps with
   | [] => pure (prune_empties [.InstVars $ vars.removeAll env])
@@ -463,43 +469,43 @@ private partial def enum_schedules {α v} [BEq v] (vars : List v) (hyps : List (
                               , .Produce out_vars hyp
                               , .Checks (Prod.fst <$> postchecks)
                               ]
-                              ++ l) (enum_schedules vars to_be_satisfied' env'')
+                              ++ l) (enumSchedules vars to_be_satisfied' env'')
 
 #guard_msgs(error, drop info) in
-#eval (enum_schedules [1,2,3,4] [("A",[[1,2,3],[4]],[]), ("B",[[4]],[])] []).take 15
+#eval (enumSchedules [1,2,3,4] [("A",[[1,2,3],[4]],[]), ("B",[[4]],[])] []).take 15
 
 -- Simple test with 2 hypotheses
 #guard_msgs(error, drop info) in
-#eval (enum_schedules [1,2,3] [("A",[[1],[2]],[]), ("B",[[2],[3]],[])] []).take 3
+#eval (enumSchedules [1,2,3] [("A",[[1],[2]],[]), ("B",[[2],[3]],[])] []).take 3
 
 -- Test with overlapping variables
 #guard_msgs(error, drop info) in
-#eval (enum_schedules [1,2,3,4,5] [("H1",[[1],[2],[3]],[]), ("H2",[[3],[4]],[]), ("H3",[[4],[5]],[])] []).take 5
+#eval (enumSchedules [1,2,3,4,5] [("H1",[[1],[2],[3]],[]), ("H2",[[3],[4]],[]), ("H3",[[4],[5]],[])] []).take 5
 
 -- Test with some variables already bound
 #guard_msgs(error, drop info) in
-#eval (enum_schedules [1,2,3] [("A",[[1],[2]],[]), ("B",[[2],[3]],[])] [1])
+#eval (enumSchedules [1,2,3] [("A",[[1],[2]],[]), ("B",[[2],[3]],[])] [1])
 
 -- Larger example to test scalability
 #guard_msgs(error, drop info) in
-#eval (enum_schedules [1,2,3,4] [("P",[[1],[2]],[]), ("Q",[[2],[3]],[]), ("R",[[3],[4]],[]), ("S",[[1],[4]],[])] []).take 10
+#eval (enumSchedules [1,2,3,4] [("P",[[1],[2]],[]), ("Q",[[2],[3]],[]), ("R",[[3],[4]],[]), ("S",[[1],[4]],[])] []).take 10
 
 -- Lots of variables (10 variables in one hypothesis)
 #guard_msgs(error, drop info) in
-#eval (enum_schedules [1,2,3,4,5,6,7,8,9,10] [("BigHyp",[[1],[2],[3],[4],[5],[6],[7],[8],[9],[10]],[])] []).take 5
+#eval (enumSchedules [1,2,3,4,5,6,7,8,9,10] [("BigHyp",[[1],[2],[3],[4],[5],[6],[7],[8],[9],[10]],[])] []).take 5
 
 -- Lots of hypotheses (10 hypotheses with few variables each)
 #guard_msgs(error, drop info) in
-#eval (enum_schedules [1,2,3,4,5,6,7,8,9,10] [("H1",[[1]],[]), ("H2",[[2]],[]), ("H3",[[3]],[]), ("H4",[[4]],[]), ("H5",[[5]],[]),
+#eval (enumSchedules [1,2,3,4,5,6,7,8,9,10] [("H1",[[1]],[]), ("H2",[[2]],[]), ("H3",[[3]],[]), ("H4",[[4]],[]), ("H5",[[5]],[]),
                        ("H6",[[6]],[]), ("H7",[[7]],[]), ("H8",[[8]],[]), ("H9",[[9]],[]), ("H10",[[10]],[])] []).take 3
 
 -- Both: many hypotheses with many variables each
 #guard_msgs(error, drop info) in
-#eval (enum_schedules (List.range 14) [("A",[[1],[2],[3],[4],[5]],[]), ("B",[[3],[4],[5],[6],[7]],[]), ("C",[[5],[6],[7],[8],[9]],[]),
+#eval (enumSchedules (List.range 14) [("A",[[1],[2],[3],[4],[5]],[]), ("B",[[3],[4],[5],[6],[7]],[]), ("C",[[5],[6],[7],[8],[9]],[]),
                        ("D",[[7],[8],[9],[10],[11],[3],[1],[2]],[]), ("E",[[9],[10],[11],[12],[13]],[])] []).take 100
 
 #guard_msgs(error, drop info) in
-#eval (@enum_schedules String Nat _ [] [] [])
+#eval (@enumSchedules String Nat _ [] [] [])
 
 -- Example for BetweenN constructor:
 -- BetweenN : ∀ n m, n <= m -> Between n (.succ n) (.succ (.succ m))
@@ -507,13 +513,22 @@ private partial def enum_schedules {α v} [BEq v] (vars : List v) (hyps : List (
 -- Hypothesis: n <= m
 -- The hypothesis "n <= m" has variables [n, m] which are both inputs (always bound)
 #guard_msgs(error, drop info) in
-#eval (enum_schedules [`n, `m] [(`n_le_m, [], [`n, `m])] [`n,`m]).take 5
+#eval (enumSchedules [`n, `m] [(`n_le_m, [], [`n, `m])] [`n,`m]).take 5
 
-partial def enum_schedules' {α v} [BEq v] (vars : List v) (hypComps : List (List (α × List (List v) × List v))) (env : List v)
+/--
+enumSchedules is a variant of enumSchedules where instead of taking a list of hypotheses to permute,
+it takes a list of simply connected components of hypotheses based on reachability in the graph
+where an edge between hypotheses exists iff their variable sets overlap. It then permutes
+only hypotheses within components but not between components. The different components are kept
+in a canonical order always, thus dramatically reducing the size of the enumeration. This is okay
+because hypotheses in different components cannot possibly depend on each other, so their ordering
+does not make a difference.
+-/
+private partial def enumSchedules' {α v} [BEq v] (vars : List v) (hypComps : List (List (α × List (List v) × List v))) (env : List v)
   : LazyList (List (PreScheduleStep α v)) :=
   match hypComps with
   | [] => pure (prune_empties [.InstVars $ vars.removeAll env])
-  | [] :: hypComps' => enum_schedules' vars hypComps' env
+  | [] :: hypComps' => enumSchedules' vars hypComps' env
   | hyps :: hypComps' => do
     let ⟨ (hyp, potential_output_indices, always_bound_variables),hyps' ⟩ ← select hyps
     let (some_bound_output_indices, all_unbound_output_indices) := List.partition (fun l => List.any l (List.contains env) || l.isEmpty) potential_output_indices
@@ -530,37 +545,37 @@ partial def enum_schedules' {α v} [BEq v] (vars : List v) (hypComps : List (Lis
                               , .Produce out_vars hyp
                               , .Checks (Prod.fst <$> postchecks)
                               ]
-                              ++ l) (enum_schedules' vars (to_be_satisfied' :: hypComps') env'')
+                              ++ l) (enumSchedules' vars (to_be_satisfied' :: hypComps') env'')
 
 #guard_msgs(error, drop info) in
-#eval (enum_schedules' [1,2,3,4] [[("A",[[1,2,3],[4]],[])], [("B",[[4]],[])]] []).take 15
+#eval (enumSchedules' [1,2,3,4] [[("A",[[1,2,3],[4]],[])], [("B",[[4]],[])]] []).take 15
 
 -- Two separate SCCs: {H1,H2} share 'a', {H3,H4} share 'd'
 #guard_msgs(error, drop info) in
-#eval (enum_schedules' ["a","b","c","d","e"] [[("H1",[["a"],["b"],["c"]],[]), ("H2",[["a"]],[])], [("H3",[["d"]],[]), ("H4",[["d"],["e"]],[])]] []).take 100
+#eval (enumSchedules' ["a","b","c","d","e"] [[("H1",[["a"],["b"],["c"]],[]), ("H2",[["a"]],[])], [("H3",[["d"]],[]), ("H4",[["d"],["e"]],[])]] []).take 100
 
 -- Three SCCs: connected chain, isolated, pair
 #guard_msgs(error, drop info) in
-#eval (enum_schedules' [1,2,3,4,5,6] [[("A",[[1],[2]],[]), ("B",[[2],[3]],[]), ("C",[[3]],[])], [("D",[[4]],[])], [("E",[[5]],[]), ("F",[[5],[6]],[])]] []).take 100
+#eval (enumSchedules' [1,2,3,4,5,6] [[("A",[[1],[2]],[]), ("B",[[2],[3]],[]), ("C",[[3]],[])], [("D",[[4]],[])], [("E",[[5]],[]), ("F",[[5],[6]],[])]] []).take 100
 
 -- Multiple single-node SCCs
 #guard_msgs(error, drop info) in
-#eval (enum_schedules' [1,2,3] [[("X",[[1]],[])], [("Y",[[2]],[])], [("Z",[[3]],[])]] []).take 2
+#eval (enumSchedules' [1,2,3] [[("X",[[1]],[])], [("Y",[[2]],[])], [("Z",[[3]],[])]] []).take 2
 
--- Comparison: enum_schedules vs enum_schedules' - total schedule counts
+-- Comparison: enumSchedules vs enumSchedules' - total schedule counts
 -- Example 1: Two separate SCCs should reduce schedules significantly
 #guard_msgs(error, drop info) in
-#eval (enum_schedules ["a","b","c","d"] [("H1",[["a"],["b"]],[]), ("H2",[["a"]],[]), ("H3",[["c"],["d"]],[]), ("H4",[["c"]],[])] []).length
+#eval (enumSchedules ["a","b","c","d"] [("H1",[["a"],["b"]],[]), ("H2",[["a"]],[]), ("H3",[["c"],["d"]],[]), ("H4",[["c"]],[])] []).length
 
 #guard_msgs(error, drop info) in
-#eval (enum_schedules' ["a","b","c","d"] [[("H1",[["a"],["b"]],[]), ("H2",[["a"]],[])], [("H3",[["c"],["d"]],[]), ("H4",[["c"]],[])]] []).length
+#eval (enumSchedules' ["a","b","c","d"] [[("H1",[["a"],["b"]],[]), ("H2",[["a"]],[])], [("H3",[["c"],["d"]],[]), ("H4",[["c"]],[])]] []).length
 
 -- Example 2: Single SCC should have same count
 #guard_msgs(error, drop info) in
-#eval (enum_schedules [1,2,3] [("A",[[1],[2]],[]), ("B",[[2],[3]],[])] []).length
+#eval (enumSchedules [1,2,3] [("A",[[1],[2]],[]), ("B",[[2],[3]],[])] []).length
 
 #guard_msgs(error, drop info) in
-#eval (enum_schedules' [1,2,3] [[("A",[[1],[2]],[]), ("B",[[2],[3]],[])]] []).length
+#eval (enumSchedules' [1,2,3] [[("A",[[1],[2]],[]), ("B",[[2],[3]],[])]] []).length
 
 -- Determine the right name for the recursive function in the producer
 private def recursiveFunctionName (deriveSort : DeriveSort) : Name :=
@@ -619,7 +634,7 @@ def convertDeriveSortToProducerSort (deriveSort : DeriveSort) : ProducerSort :=
   | .Checker | .Enumerator => ProducerSort.Enumerator
   | .Generator | .Theorem => ProducerSort.Generator
 
-def typePreScheduleStep {α} (tyMap : NameMap Expr) (step : PreScheduleStep α Name) : (PreScheduleStep α TypedVar) :=
+private def typePreScheduleStep {α} (tyMap : NameMap Expr) (step : PreScheduleStep α Name) : (PreScheduleStep α TypedVar) :=
   match step with
   | .Checks hyps => .Checks hyps
   | .Produce out hyp =>
@@ -665,34 +680,14 @@ def possibleSchedules (vars : List TypedVar) (hypotheses : List HypothesisExpr) 
   let remainingSortedHypotheses := filterWithIndex (fun i _ => i ∉ newCheckedIdxs) sortedHypotheses
   let connectedHypotheses := (computeSCC (remainingSortedHypotheses.map (fun (h,vars) => ((h,vars),vars.flatten)))).map (List.map fun ((h,vars),_) => constructHypothesis (h,vars))
   let firstChecks := List.reverse $ (ScheduleStep.Check . true) <$> newCheckedHyps
-  let lazyPreSchedules : LazyList (List (PreScheduleStep HypothesisExpr Name)) := enum_schedules' remainingVars connectedHypotheses fixedVars
+  let lazyPreSchedules : LazyList (List (PreScheduleStep HypothesisExpr Name)) := enumSchedules' remainingVars connectedHypotheses fixedVars
   let nameTypeMap := List.foldl (fun m ⟨name,ty⟩ => NameMap.insert m name ty) ∅ vars
   let typedPreSchedules : LazyList (List (PreScheduleStep HypothesisExpr TypedVar)) := lazyPreSchedules.mapLazyList (List.map (typePreScheduleStep nameTypeMap))
   let lazySchedules := typedPreSchedules.mapLazyList ((ReaderT.run . scheduleEnv) ∘ ((firstChecks ++ .) <$> .) ∘ List.flatMapM preScheduleStepToScheduleStep)
   lazySchedules
 
--- Complex example with many hypotheses (ValidCtrlAl constructor)
-#guard_msgs(error, drop info) in
-#eval computeSCC [("ValidAluHeader", ["header"]), ("ValidEvents", ["events"]), ("ValidDtype64", ["dtype"]), ("ValidAluOp", ["op"]), ("ValidRegisterRead", ["src0_lo"]), ("ValidRegisterRead", ["src0_hi"]), ("ValidRegisterRead", ["src1_lo"]), ("ValidRegisterRead", ["src1_hi"]), ("ValidRegisterWrite", ["dst_lo"]), ("ValidRegisterWrite", ["dst_hi"]), ("CtrlAlValidRegisterOpCombination", ["op", "dtype"]), ("CtrlAlValidDtype", ["dtype"])]
-
-#guard_msgs(error, drop info) in
-#eval (enum_schedules ["header", "events", "dtype", "op", "src0_lo", "src0_hi", "src1_lo", "src1_hi", "dst_lo", "dst_hi"] [("ValidAluHeader", [["header"]],[]), ("ValidEvents", [["events"]],[]), ("ValidDtype64", [["dtype"]],[]), ("ValidAluOp", [["op"]],[]), ("ValidRegisterRead1", [["src0_lo"]],[]), ("ValidRegisterRead2", [["src0_hi"]],[]), ("ValidRegisterRead3", [["src1_lo"]],[]), ("ValidRegisterRead4", [["src1_hi"]],[]), ("ValidRegisterWrite1", [["dst_lo"]],[]), ("ValidRegisterWrite2", [["dst_hi"]],[]), ("CtrlAlValidRegisterOpCombination", [["op"], ["dtype"]],[]), ("CtrlAlValidDtype", [["dtype"]],[])] []).take 3
-
-#guard_msgs(error, drop info) in
-#eval (enum_schedules' ["header", "events", "dtype", "op", "src0_lo", "src0_hi", "src1_lo", "src1_hi", "dst_lo", "dst_hi", "datasrc", "imm"]
-  [[("ValidAluHeader", [["header"]],[])],
-   [("ValidEvents", [["events"]],[])],
-   [("ValidDtype64", [["dtype"],[],[],[]],[]), ("CtrlAlValidRegisterOpCombination", [["op"], ["dtype"]],[]), ("ValidAluOp", [["op"]],[]), ("CtrlAlValidDtype", [["dtype"]],[])],
-   [("ValidRegisterRead1", [["src0_lo"]],[])],
-   [("ValidRegisterRead2", [["src0_hi"]],[])],
-   [("ValidRegisterRead3", [["src1_lo"]],[])],
-   [("ValidRegisterRead4", [["src1_hi"]],[])],
-   [("ValidRegisterWrite1", [["dst_lo"]],[])],
-   [("ValidRegisterWrite2", [["dst_hi"]],[])]] [
-   ]).length
-
 private def tryTypedSchedules (vars : List (Name × Expr)) hyps := do
-  let lazyPreSchedules : LazyList (List (PreScheduleStep Name Name)) := enum_schedules (List.map (fun ((name, _typ) : Name × Expr) => name) vars) hyps []
+  let lazyPreSchedules : LazyList (List (PreScheduleStep Name Name)) := enumSchedules (List.map (fun ((name, _typ) : Name × Expr) => name) vars) hyps []
   let nameTypeMap := List.foldl (fun m (name, (ty : Expr)) => NameMap.insert m name ty) ∅ vars
   let typedPreSchedules : LazyList (List (PreScheduleStep Name TypedVar)) := lazyPreSchedules.mapLazyList (List.map (typePreScheduleStep nameTypeMap))
   typedPreSchedules

--- a/Plausible/Chamelean/DeriveSchedules.lean
+++ b/Plausible/Chamelean/DeriveSchedules.lean
@@ -258,7 +258,7 @@ private def subsetsAndComplements {α} (as : List α) : LazyList (List α × Lis
   | [] => pure ([],[])
   | a :: as' => do
     let (subset,comp) ← subsetsAndComplements as'
-    .lcons (a :: subset,comp) ⟨ fun _ => .lcons (subset,a :: comp) ⟨fun _ => .lnil⟩⟩
+    .lcons (a :: subset, comp) ⟨ fun _ => .lcons (subset, a :: comp) ⟨fun _ => .lnil⟩⟩
 
 /- Unused utility function for future if we wish to prune selections of hypotheses by some predicate -/
 private def subsetsAndComplementsSuchThat {α} (p : α -> Bool) (as : List α) : LazyList (List α × List α) :=
@@ -316,6 +316,8 @@ private def constructHypothesis (hyp : HypothesisExpr × List (List Name)) : Hyp
   let hypIndices := List.zip hyp.fst.snd hyp.snd
   let (mustBind, allSafe) := hypIndices.partition (fun (ctrExpr, vars) =>
     containsFunctionCall ctrExpr || (vars.any (List.contains repeatedNames)))
+  -- Any variables that appear multiple times in a hypothesis will end up in mustBind the same number of times, so we must deduplicate
+  -- to avoid instantiating it multiple times.
   (hyp.fst, allSafe.map (fun x => x.snd), (List.eraseDups mustBind).flatMap (fun x => x.snd))
 
 private def needs_checking {α v} [BEq v] (env : List v) (a_vars : α × List (List v) × List v) : Bool :=
@@ -516,7 +518,7 @@ private partial def enumSchedules {α v} [BEq v] (vars : List v) (hyps : List (�
 #eval (enumSchedules [`n, `m] [(`n_le_m, [], [`n, `m])] [`n,`m]).take 5
 
 /--
-enumSchedules is a variant of enumSchedules where instead of taking a list of hypotheses to permute,
+`enumSchedules'` is a variant of `enumSchedules` where instead of taking a list of hypotheses to permute,
 it takes a list of simply connected components of hypotheses based on reachability in the graph
 where an edge between hypotheses exists iff their variable sets overlap. It then permutes
 only hypotheses within components but not between components. The different components are kept

--- a/Plausible/Chamelean/LazyList.lean
+++ b/Plausible/Chamelean/LazyList.lean
@@ -71,6 +71,13 @@ def mapLazyList (f : α → β) (l : LazyList α) : LazyList β :=
   | .lnil => .lnil
   | .lcons x xs => .lcons (f x) ⟨fun _ => mapLazyList f xs.get⟩
 
+def length (l : LazyList α) : Nat :=
+  let rec aux l n :=
+    match l with
+    | .lnil => n
+    | .lcons _ xs => aux xs.get (1 + n)
+  aux l 0
+
 /-- `Functor` instance for `LazyList` -/
 instance : Functor LazyList where
   map := mapLazyList

--- a/Plausible/Chamelean/LazyList.lean
+++ b/Plausible/Chamelean/LazyList.lean
@@ -71,6 +71,7 @@ def mapLazyList (f : α → β) (l : LazyList α) : LazyList β :=
   | .lnil => .lnil
   | .lcons x xs => .lcons (f x) ⟨fun _ => mapLazyList f xs.get⟩
 
+/-- Length of a LazyList. Warning: this forces the whole list. -/
 def length (l : LazyList α) : Nat :=
   let rec aux l n :=
     match l with

--- a/Plausible/Chamelean/Schedules.lean
+++ b/Plausible/Chamelean/Schedules.lean
@@ -152,6 +152,9 @@ partial def exprToConstructorExpr (e : Expr) : MetaM ConstructorExpr := do
       return ConstructorExpr.FuncApp name (args ++ [argExpr])
     | ConstructorExpr.Unknown name =>
       throwError m!"exprToConstructorExpr: We do not support higher order application of {name} in Expr {e}"
+    | ConstructorExpr.Lit _ =>
+      throwError m!"exprToConstructorExpr: String and Nat Literals cannot be applied as functions, see: {f} in {e}"
+  | .lit l => return ConstructorExpr.Lit l
   | _ =>
     -- For other expression types (literals, lambdas, etc.), generate a placeholder name
     throwError m!"exprToConstructorExpr can only handle free variables, constants, and applications. Attempted to convert: {e}"

--- a/Plausible/Chamelean/TSyntaxCombinators.lean
+++ b/Plausible/Chamelean/TSyntaxCombinators.lean
@@ -82,7 +82,10 @@ def mkMatchExprWithScrutineeTerm (scrutinee : TSyntax `term) (cases : TSyntaxArr
 def mkDoElemMatchExpr (scrutinee : TSyntax `term) (cases : TSyntaxArray ``Term.matchAlt) : MetaM (TSyntax `doElem) :=
   `(doElem| match $scrutinee:term with $cases:matchAlt*)
 
+/-- Converts a `Literal`, the datatype used to store `Nat` and `String` literals in `Lean.Expr` into the corresponding literal `TSyntax`.
+    Note, the `Nat` literal will be wrapped in an `OfNat.ofNat` call.
+-/
 def mkLiteral (l : Literal) : MetaM (TSyntax `term) :=
   match l with
-  | .natVal n => `($(Syntax.mkNumLit (toString n)))
+  | .natVal n => `($(Syntax.mkNatLit n))
   | .strVal s => `($(Syntax.mkStrLit s))

--- a/Plausible/Chamelean/TSyntaxCombinators.lean
+++ b/Plausible/Chamelean/TSyntaxCombinators.lean
@@ -81,3 +81,8 @@ def mkMatchExprWithScrutineeTerm (scrutinee : TSyntax `term) (cases : TSyntaxArr
     is a `doElem` (i.e. it is part of a monadic `do`-block) -/
 def mkDoElemMatchExpr (scrutinee : TSyntax `term) (cases : TSyntaxArray ``Term.matchAlt) : MetaM (TSyntax `doElem) :=
   `(doElem| match $scrutinee:term with $cases:matchAlt*)
+
+def mkLiteral (l : Literal) : MetaM (TSyntax `term) :=
+  match l with
+  | .natVal n => `($(Syntax.mkNumLit (toString n)))
+  | .strVal s => `($(Syntax.mkStrLit s))

--- a/Plausible/Chamelean/UnificationMonad.lean
+++ b/Plausible/Chamelean/UnificationMonad.lean
@@ -566,7 +566,8 @@ mutual
       handleMatch u (.Lit l)
     | (_, .Lit l), (u, .Fixed) =>
       handleMatch u (.Lit l)
-    | (_u,r), (_u',r') => throwError m!"unifyC: unable to unify {r}, {r'} when one is a constructor and the other is a literal."
+    | (_u1, .Lit l), (_u2, c@(.Ctor _ _)) => throwError m!"unifyC: unable to unify literal {repr l} with constructor {c}"
+    | (_u1, c@(.Ctor _ _)), (_u2, .Lit l) => throwError m!"unifyC: unable to unify constructor {c} with literal {repr l}"
 
   partial def unifyL (l l' : Literal) : UnifyM Unit :=
     if l == l' then

--- a/Plausible/Chamelean/UnificationMonad.lean
+++ b/Plausible/Chamelean/UnificationMonad.lean
@@ -348,11 +348,11 @@ def findUnknownsWithUndefRanges (unknowns : List Unknown) : UnifyM (List Unknown
     | .Undef _ => return (u :: acc)
     | _ => return acc) [] unknowns
 
-  /-- Updates the `constraint` map so that for each `u ∈ unknowns`,
-      we have the binding `u ↦ Fixed` in the `UnknownMap` `constraints`
-      - Note: this doesn't handle chains of `Unknown`s in `constraints` -/
+/-- Updates the `constraint` map so that for each `u ∈ unknowns`,
+    we have the binding `u ↦ Fixed` in the `UnknownMap` `constraints`
+    - Note: this doesn't handle chains of `Unknown`s in `constraints` -/
 def fixRanges (unknowns : List Unknown) : UnifyM Unit := do
-  updateMany (unknowns.map (fun u => (u,.Fixed)))
+  updateMany (unknowns.map (fun u => (u, .Fixed)))
 
 /-- `fixRangeHandleUnknownChains u` updates the `constraint` map
     so that we have the binding `u ↦ Fixed` in the `UnknownMap` `constraints`

--- a/Plausible/Chamelean/UnificationMonad.lean
+++ b/Plausible/Chamelean/UnificationMonad.lean
@@ -3,6 +3,7 @@ import Std.Data.HashMap
 import Lean.Expr
 import Lean.Exception
 import Plausible.Chamelean.Idents
+import Plausible.Chamelean.TSyntaxCombinators
 
 
 open Lean Idents Elab
@@ -38,13 +39,19 @@ inductive Range
 
   /-- A `Range` can be a constructor `C` fully applied to a list of `Range`s -/
   | Ctor (ctor : Name) (rs : List Range)
+  | Lit (l : Literal)
   deriving Repr, Inhabited, BEq
+
+deriving instance Ord for Literal
 
 /-- A `Pattern` is either an unknown or a fully-applied constructor -/
 inductive Pattern
   | UnknownPattern : Unknown -> Pattern
   | CtorPattern : Name -> List Pattern -> Pattern
+  | LitPattern : Literal → Pattern
   deriving Repr, Inhabited, BEq, Ord
+
+
 
 /-- A *constructor expression* (`ConstructorExpr`) is either a variable (represented by its `Name`),
     or a constructor (identified by its `Name`) applied to some list of arguments,
@@ -53,9 +60,10 @@ inductive Pattern
     - Note: this type is isomorphic to `Pattern`, but we define a separate type to avoid confusing
     `ConstructorExpr` with `Pattern` since they are used in different parts of the algorithm -/
 inductive ConstructorExpr
-  | Unknown : Name -> ConstructorExpr
-  | Ctor : Name -> List ConstructorExpr -> ConstructorExpr
-  | FuncApp : Name -> List ConstructorExpr -> ConstructorExpr
+  | Unknown : Name → ConstructorExpr
+  | Ctor : Name → List ConstructorExpr → ConstructorExpr
+  | FuncApp : Name → List ConstructorExpr → ConstructorExpr
+  | Lit : Literal → ConstructorExpr
   deriving Repr, BEq, Inhabited, Ord
 
 /-- Converts a `ConstructorExpr` to a Lean `Expr` -/
@@ -66,6 +74,7 @@ partial def constructorExprToExpr (ctorExpr : ConstructorExpr) : Expr :=
     mkAppN (mkConst ctorName) (constructorExprToExpr <$> ctorArgs.toArray)
   | .FuncApp funcName ctorArgs =>
     mkAppN (mkConst funcName) (constructorExprToExpr <$> ctorArgs.toArray)
+  | .Lit l => .lit l
 
 /-- `ToExpr` instance for `ConstructorExpr` -/
 instance : ToExpr ConstructorExpr where
@@ -80,6 +89,7 @@ partial def constructorExprToTSyntaxTerm (ctorExpr : ConstructorExpr) : MetaM (T
   | .FuncApp ctorName ctorArgs => do
     let argTerms ← ctorArgs.toArray.mapM constructorExprToTSyntaxTerm
     `($(mkIdent ctorName) $argTerms:term*)
+  | .Lit l => mkLiteral l
 
 
 /-- Converts a `Pattern` to an equivalent `ConstructorExpr` -/
@@ -87,6 +97,7 @@ partial def constructorExprOfPattern (pattern : Pattern) : ConstructorExpr :=
   match pattern with
   | .UnknownPattern u => .Unknown u
   | .CtorPattern ctorName args => .Ctor ctorName (constructorExprOfPattern <$> args)
+  | .LitPattern l => .Lit l
 
 /-- Converts a `ConstructorExpr` to an equivalent `Pattern` -/
 partial def patternOfConstructorExpr (ctorExpr : ConstructorExpr) : Option Pattern :=
@@ -94,6 +105,7 @@ partial def patternOfConstructorExpr (ctorExpr : ConstructorExpr) : Option Patte
   | .Unknown u => some $ .UnknownPattern u
   | .Ctor ctorName args => .CtorPattern ctorName <$> (List.mapM patternOfConstructorExpr args)
   | .FuncApp _ _ => none
+  | .Lit l => some $ .LitPattern l
 
 
 /-- An `UnknownMap` maps `Unknown`s to `Range`s -/
@@ -157,6 +169,7 @@ partial def toMessageDataRange (range : Range) : MessageData :=
     m!"Ctor ({c} {rendredCtorArgs})"
   | .Unknown u => m!"Unknown {u}"
   | .Fixed => m!"Fixed"
+  | .Lit l => m!"Lit {repr l}"
 
 instance : ToMessageData Range where
   toMessageData := toMessageDataRange
@@ -168,6 +181,8 @@ partial def toMessageDataPattern (p : Pattern) : MessageData :=
   | .CtorPattern c ps =>
     let renderedCtorArgs := toMessageDataPattern <$> ps
     m!"CtorPattern ({c} {renderedCtorArgs})"
+  | .LitPattern l =>
+    m!"LitPattern {repr l}"
 
 instance : ToMessageData Pattern where
   toMessageData pattern := toMessageDataPattern pattern
@@ -182,6 +197,7 @@ partial def toMessageDataConstructorExpr (ctorExpr : ConstructorExpr) : MessageD
   | .FuncApp f args =>
     let renderedArgs := toMessageDataConstructorExpr <$> args
     m!"FuncApp ({f} {renderedArgs})"
+  | .Lit l => m!"Lit {repr l}"
 
 instance : ToMessageData ConstructorExpr where
   toMessageData := toMessageDataConstructorExpr
@@ -319,6 +335,7 @@ partial def hasFixedRange (k : UnknownMap) (r : Range) : UnifyM Bool := do
     let range ← findCorrespondingRange k u
     hasFixedRange k range
   | .Ctor _ rs => rs.allM (hasFixedRange k)
+  | .Lit _ => return true
 
 /-- `findUnknownsWithUndefRanges unknowns` returns all `u ∈ unknowns`
     such that `u ↦ Undef τ` for some type `τ` in the `constraints` map stored within `UnifyState` -/
@@ -331,11 +348,11 @@ def findUnknownsWithUndefRanges (unknowns : List Unknown) : UnifyM (List Unknown
     | .Undef _ => return (u :: acc)
     | _ => return acc) [] unknowns
 
-/-- Updates the `constraint` map so that for each `u ∈ unknowns`,
-    we have the binding `u ↦ Fixed` in the `UnknownMap` `constraints`
-    - Note: this doesn't handle chains of `Unknown`s in `constraints` -/
+  /-- Updates the `constraint` map so that for each `u ∈ unknowns`,
+      we have the binding `u ↦ Fixed` in the `UnknownMap` `constraints`
+      - Note: this doesn't handle chains of `Unknown`s in `constraints` -/
 def fixRanges (unknowns : List Unknown) : UnifyM Unit := do
-  updateMany (unknowns.zip (List.replicate unknowns.length .Fixed))
+  updateMany (unknowns.map (fun u => (u,.Fixed)))
 
 /-- `fixRangeHandleUnknownChains u` updates the `constraint` map
     so that we have the binding `u ↦ Fixed` in the `UnknownMap` `constraints`
@@ -365,6 +382,7 @@ partial def fixRangeHandleUnknownChains (u : Unknown) : UnifyM Unit := do
         | .Ctor _ rs =>
           for range in rs do
             fixRange `unusedParameter range
+        | .Lit _ => return ()
 
 /--`findCanonicalUnknown k u` finds the *canonical* representation of the unknown `u` based on the `ConstraintMap` `k`.
     Specifically:
@@ -399,6 +417,7 @@ partial def updateConstructorArg (k : UnknownMap) (ctorArg : ConstructorExpr) : 
   | .FuncApp ctorName args =>
     let updatedArgs ← args.mapM (updateConstructorArg k)
     return (.Ctor ctorName updatedArgs)
+  | .Lit l => return .Lit l
 
 /-- `updatePattern k p` uses the `UnknownMap` `k` to rewrite any unknowns that appear in the
     `Pattern` `p`, substituting each `Unknown` with its canonical representation
@@ -410,6 +429,7 @@ partial def updatePattern (k : UnknownMap) (p : Pattern) : UnifyM Pattern := do
   | .CtorPattern c args => do
     let updatedArgs ← args.mapM (updatePattern k)
     return .CtorPattern c updatedArgs
+  | .LitPattern l => return .LitPattern l
 
 /-- Extends the current state with the contents of the fields in `newState`
     (Note that the `outputName` and `outputType` of `newStates` are used) -/
@@ -425,17 +445,6 @@ def extendState (newState : UnifyState) : UnifyM Unit := do
     hypotheses := s.hypotheses ++ newState.hypotheses
   }
 
-
-/-- Converts an array of `ConstructorExpr`s to one single `TSyntaxArray term`-/
-partial def convertConstructorExprsToTSyntaxTerms (ctorExprs : Array ConstructorExpr) : UnifyM (TSyntaxArray `term) :=
-  ctorExprs.mapM (fun ctorExpr => do
-    match ctorExpr with
-    | .Unknown u => `($(Lean.mkIdent u))
-    | .Ctor c args
-    | .FuncApp c args =>
-      let argTerms ← convertConstructorExprsToTSyntaxTerms args.toArray
-      `($(mkIdent c) $argTerms*))
-
 /-- Accumulates all the `Unknown`s in a `ConstructorExpr` -/
 def collectUnknownsInConstructorExpr (ctorExpr : ConstructorExpr) : List Unknown :=
   match ctorExpr with
@@ -443,6 +452,7 @@ def collectUnknownsInConstructorExpr (ctorExpr : ConstructorExpr) : List Unknown
   | .Ctor c args
   | .FuncApp c args =>
     c :: List.flatMap collectUnknownsInConstructorExpr args
+  | .Lit _ => []
 
 mutual
   /-- Evaluates a `Range`, returning a `ConstructorExpr`. Note that if the
@@ -453,6 +463,7 @@ mutual
       let args' ← List.mapM evaluateRange args
       return (ConstructorExpr.Ctor c args')
     | .Unknown u => evaluateUnknown u
+    | .Lit l => return .Lit l
     | .Fixed | .Undef _ =>
       throwError m!"unable to evaluate range {r}"
 
@@ -470,6 +481,7 @@ mutual
       | .Ctor c args => do
         let args' ← args.mapM evaluateRange
         return (ConstructorExpr.Ctor c args')
+      | .Lit l => return .Lit l
 end
 
 /-- Determines whether a `Range` is `Fixed`. If the `Range` is in the form `Unknown u`,
@@ -485,6 +497,7 @@ partial def isRangeFixed (r : Range) : UnifyM Bool :=
       | none => return false
       | some r' => isRangeFixed r'
   | .Ctor _ args => List.allM isRangeFixed args
+  | .Lit _ => return true
 
 /-- Determines if an `Unknown` has a `Fixed` `Range` in the `UnknownMap`
     (this handles chains of `Unknowns` in the `UnknownMap`) -/
@@ -521,6 +534,15 @@ mutual
       UnifyM.withConstraints $ fun k => do
         let r2 ← UnifyM.findCorrespondingRange k u2
         unifyRC (u2, r2) c1
+    | .Lit l, .Lit l' => unifyL l l'
+    | .Unknown u1, .Lit l =>
+      UnifyM.withConstraints $ fun k => do
+        let r1 ← UnifyM.findCorrespondingRange k u1
+        unifyRC (u1, r1) (.Lit l)
+    | .Lit l, .Unknown u2 =>
+      UnifyM.withConstraints $ fun k => do
+        let r2 ← UnifyM.findCorrespondingRange k u2
+        unifyRC (u2, r2) (.Lit l)
     | r1, r2 => throwError "Unable to unify {r1} with {r2}"
 
   /-- Takes two `(Unknown, Range)` pairs & unifies them based on their `Range`s -/
@@ -539,6 +561,20 @@ mutual
       UnifyM.update u1 (.Unknown u2)
     | (u1, .Fixed), (_, c2@(.Ctor _ _)) => handleMatch u1 c2
     | (_, c1@(.Ctor _ _)), (u2, .Fixed) => handleMatch u2 c1
+    | (_u1, .Lit l), (_u2, .Lit l') => unifyL l l'
+    | (u, .Fixed), (_u', .Lit l) =>
+      handleMatch u (.Lit l)
+    | (_, .Lit l), (u, .Fixed) =>
+      handleMatch u (.Lit l)
+    | (_u,r), (_u',r') => throwError m!"unifyC: unable to unify {r}, {r'} when one is a constructor and the other is a literal."
+
+  partial def unifyL (l l' : Literal) : UnifyM Unit :=
+    if l == l' then
+      return ()
+    else do
+      let st ← get
+      let constraints := st.constraints
+      throwError m!"unifyC: unable to unify {repr $ Range.Lit l} with {repr $ Range.Lit l'}, constraints = {constraints.toList}, literals not equal."
 
   /-- Unifies two `Range`s that are both constructors -/
   partial def unifyC (r1 : Range) (r2 : Range) : UnifyM Unit :=
@@ -557,13 +593,17 @@ mutual
 
   /-- Unifies an `(Unknown, Range)` pair with a `Range` -/
   partial def unifyRC : Unknown × Range → Range → UnifyM Unit
-    | (u1, .Undef _), c2@(.Ctor _ _) => UnifyM.update u1 c2
-    | (_, .Unknown u'), c2@(.Ctor _ _) =>
+    | (u1, .Undef _), c2@(.Ctor _ _)
+    | (u1, .Undef _), c2@(.Lit _) => UnifyM.update u1 c2
+    | (_, .Unknown u'), c2@(.Ctor _ _)
+    |  (_, .Unknown u'), c2@(.Lit _) =>
       UnifyM.withConstraints $ fun k => do
         let r ← UnifyM.findCorrespondingRange k u'
         unifyRC (u', r) c2
-    | (u, .Fixed), c2@(.Ctor _ _) => handleMatch u c2
+    | (u, .Fixed), c2@(.Ctor _ _)
+    | (u, .Fixed), c2@(.Lit _) => handleMatch u c2
     | (_, c1@(.Ctor _ _)), c2@(.Ctor _ _) => unifyC c1 c2
+    | (_, .Lit l), .Lit l' => unifyL l l'
     | (u, r), r' => throwError m!"unifyRC called, unable to unify (unknown {u}, range {r}) with range {r'}"
 
   /-- Corresponds to `match` in the pseudocode
@@ -573,6 +613,8 @@ mutual
     | u, .Ctor c rs => do
       let ps ← rs.mapM matchAux
       UnifyM.addPattern u (Pattern.CtorPattern c ps)
+    | u, .Lit l =>
+      UnifyM.addPattern u (Pattern.LitPattern l)
     | u, r => throwError m!"handleMatch called, unable to match unknown {u} with range {r} which is not in constructor form"
 
   /-- `matchAux` traverses a `Range` and converts it into a
@@ -582,7 +624,7 @@ mutual
     | .Ctor c rs => do
       -- Recursively handle ranges
       let ps ← rs.mapM matchAux
-      return (.CtorPattern c ps)
+      return .CtorPattern c ps
     | .Unknown u => UnifyM.withConstraints $ fun k => do
       let r ← UnifyM.findCorrespondingRange k u
       match r with
@@ -592,7 +634,7 @@ mutual
         -- We update `u`'s range to be `fixed`
         -- (since we're extracting information out of the scrutinee)
         UnifyM.update u .Fixed
-        return (.UnknownPattern u)
+        return .UnknownPattern u
       | .Fixed => do
         -- Handles non-linear patterns:
         -- produce a fresh unknown `u'`, use `u'` as the pattern variable
@@ -600,11 +642,14 @@ mutual
         let u' ← UnifyM.registerFreshUnknown
         UnifyM.registerEquality u' u
         UnifyM.update u' r
-        return (.UnknownPattern u')
+        return .UnknownPattern u'
       | u'@(.Unknown _) => matchAux u'
       | .Ctor c rs => do
         let ps ← rs.mapM matchAux
-        return (.CtorPattern c ps)
+        return .CtorPattern c ps
+      | .Lit l =>
+        return .LitPattern l
+    | .Lit l => return .LitPattern l
     | _ => throwError m!"matchAux called with unexpected range {range}"
 
 end

--- a/Plausible/Chamelean/Utils.lean
+++ b/Plausible/Chamelean/Utils.lean
@@ -35,6 +35,7 @@ def containsNonTrivialFuncApp (e : Expr) (inductiveRelationName : Name) : MetaM 
       return false
 
   match e with
+  | (.app (.app (.app (.const ``OfNat.ofNat _) _) (.lit _)) _) => return false
   | .app f arg =>
     if (← checkSubTerm f)
       then return true
@@ -49,6 +50,7 @@ def containsNonTrivialFuncApp (e : Expr) (inductiveRelationName : Name) : MetaM 
       checkSubTerm body
   | .mdata _ expr => checkSubTerm expr
   | .proj _ _ struct => checkSubTerm struct
+  | .lit _ => return false
   | _ => return false
 
 

--- a/Plausible/Gen.lean
+++ b/Plausible/Gen.lean
@@ -206,7 +206,7 @@ def Gen.printSamples {t : Type} [Repr t] (g : Gen t) : IO PUnit := do
   let xs : List t ← (List.range 10).mapM (Gen.run g)
   let xs := xs.map repr
   for x in xs do
-    IO.println s!"{x}"
+    IO.println s!"{x}\n"
 
 /-- Execute a `Gen` until it actually produces an output. May diverge for bad generators! -/
 partial def Gen.runUntil {α : Type} (attempts : Option Nat := .none) (x : Gen α) (size : Nat) : IO α :=

--- a/Test/CedarExample/CedarCheckerGenerators.lean
+++ b/Test/CedarExample/CedarCheckerGenerators.lean
@@ -104,6 +104,9 @@ deriving instance DecidableEq for PathSet
 #derive_checker (WfRecordType n r)
 
 #guard_msgs(drop info, drop warning) in
+#derive_checker (BindAttrType ns TE t)
+
+#guard_msgs(drop info, drop warning) in
 #derive_generator (fun (ns : _) => BindAttrType ns TE t_1)
 
 #guard_msgs(drop info, drop warning) in
@@ -303,10 +306,14 @@ set_option maxHeartbeats 2000000
 -- Generator for well-typed Cedar expressions
 ------------------------------------------------------------
 
-#guard_msgs(drop info, drop warning) in
-#derive_checker (HasTypePrim a b t)
-
 -- #guard_msgs(drop info, drop warning) in
+-- #derive_checker (HasTypePrim a b t)
+
+-- #derive_enumerator (fun (t : _) => HasType a v e t)
+
+-- #derive_checker (HasType a v e t)
+
+-- -- #guard_msgs(drop info, drop warning) in
 -- #derive_generator (fun (t : _) => HasType a v ex t)
 
 -- #guard_msgs(drop info, drop warning) in

--- a/Test/CedarExample/CedarCheckerGenerators.lean
+++ b/Test/CedarExample/CedarCheckerGenerators.lean
@@ -301,22 +301,12 @@ set_option maxHeartbeats 2000000
 #guard_msgs(drop info, drop warning) in
 #derive_generator (fun (tef : (CedarType × String × Bool)) => BindAttrType ns tef t)
 
+#guard_msgs(drop info) in
+#derive_generator (fun (T : _) => BindAttrType ns (TE, F, true) T)
 
 ------------------------------------------------------------
 -- Generator for well-typed Cedar expressions
 ------------------------------------------------------------
 
--- #guard_msgs(drop info, drop warning) in
--- #derive_checker (HasTypePrim a b t)
-
--- #derive_enumerator (fun (t : _) => HasType a v e t)
-
--- #derive_checker (HasType a v e t)
-
--- -- #guard_msgs(drop info, drop warning) in
--- #derive_generator (fun (t : _) => HasType a v ex t)
-
-#derive_generator (fun (T : _) => BindAttrType ns (TE, F, true) T)
-
-#guard_msgs(drop warning) in
+#guard_msgs(drop info, drop warning) in
 #derive_generator (fun (ex : (CedarExpr × PathSet)) => HasType a v ex t)

--- a/Test/CedarExample/CedarCheckerGenerators.lean
+++ b/Test/CedarExample/CedarCheckerGenerators.lean
@@ -316,5 +316,7 @@ set_option maxHeartbeats 2000000
 -- -- #guard_msgs(drop info, drop warning) in
 -- #derive_generator (fun (t : _) => HasType a v ex t)
 
--- #guard_msgs(drop info, drop warning) in
--- #derive_generator (fun (ex : (CedarExpr × PathSet)) => HasType a v ex t)
+#derive_generator (fun (T : _) => BindAttrType ns (TE, F, true) T)
+
+#guard_msgs(drop warning) in
+#derive_generator (fun (ex : (CedarExpr × PathSet)) => HasType a v ex t)

--- a/Test/CedarExample/CedarWellTypedTermGenerator.lean
+++ b/Test/CedarExample/CedarWellTypedTermGenerator.lean
@@ -46,19 +46,19 @@ def schema : Schema :=
   Schema.MkSchema ets acts
 
 /- A generator for well-typed Cedar expressions, using the derived generators for `RequestTypes`, environments and expressions -/
--- def genCedarExpr (fuel : Nat) : Gen CedarExpr :=
---   match schema with
---   | .MkSchema ets acts => do
---     -- Generates `RequestTypes` based on the schema
---     let reqs ← ArbitrarySizedSuchThat.arbitrarySizedST (fun rs => ActionSchemaToRequestTypes acts [] rs) fuel
---     -- Generate a list of environments `envs`
---     let envs ← ArbitrarySizedSuchThat.arbitrarySizedST (fun es => SchemaToEnvironments (.MkSchema ets acts) reqs es) fuel
---     match envs with
---     | v :: _ => do
---       -- Generate a well-typed expression from the first environment `v` in `es`
---       let (expr, _) ← ArbitrarySizedSuchThat.arbitrarySizedST (fun e => HasType (.somepaths []) v e (.boolType .anyBool)) fuel
---       return expr
---     | [] => throw Gen.genericFailure
+def genCedarExpr (fuel : Nat) : Gen CedarExpr :=
+  match schema with
+  | .MkSchema ets acts => do
+    -- Generates `RequestTypes` based on the schema
+    let reqs ← ArbitrarySizedSuchThat.arbitrarySizedST (fun rs => ActionSchemaToRequestTypes acts [] rs) fuel
+    -- Generate a list of environments `envs`
+    let envs ← ArbitrarySizedSuchThat.arbitrarySizedST (fun es => SchemaToEnvironments (.MkSchema ets acts) reqs es) fuel
+    match envs with
+    | v :: _ => do
+      -- Generate a well-typed expression from the first environment `v` in `es`
+      let (expr, _) ← ArbitrarySizedSuchThat.arbitrarySizedST (fun e => HasType (.somepaths []) v e (.boolType .anyBool)) fuel
+      return expr
+    | [] => throw Gen.genericFailure
 
 /- Below are some Cedar expressions that are produced by the generator above.
 Note that these are *not* well-typed Cedar expressions, because we commented out 18 out of the 41 typing rules in `HasType`
@@ -134,4 +134,4 @@ deriving instance Repr for RequestType
   ArbitrarySizedSuchThat.arbitrarySizedST (fun rs => ActionSchemaToRequestTypes acts [] rs) 5)
 -- #print genCedarExpr
 -- Uncomment this line to see the output from the generator for Cedar expressions
--- #eval runSizedGenPrintOutput genCedarExpr 1
+#eval Gen.printSamples (genCedarExpr 5)

--- a/Test/CedarExample/CedarWellTypedTermGenerator.lean
+++ b/Test/CedarExample/CedarWellTypedTermGenerator.lean
@@ -12,7 +12,7 @@ Note: the structure of this file closely follows Mike Hicks's Coq formalization 
 -/
 
 /-- Schema based on one of Cedar's sample apps -/
-def schema : Schema :=
+private def schema : Schema :=
   -- entity types
   let team := EntityName.MkName "Team" []
   let teamDef := EntitySchemaEntry.MkEntitySchemaEntry [team] []
@@ -46,7 +46,7 @@ def schema : Schema :=
   Schema.MkSchema ets acts
 
 /- A generator for well-typed Cedar expressions, using the derived generators for `RequestTypes`, environments and expressions -/
-def genCedarExpr (fuel : Nat) : Gen CedarExpr :=
+private def genCedarExpr (fuel : Nat) : Gen CedarExpr :=
   match schema with
   | .MkSchema ets acts => do
     -- Generates `RequestTypes` based on the schema
@@ -132,6 +132,29 @@ deriving instance Repr for RequestType
     ((EntityUID.MkEntityUID action "createList"), createAct),
     ((EntityUID.MkEntityUID action "updateList"), updateAct)]
   ArbitrarySizedSuchThat.arbitrarySizedST (fun rs => ActionSchemaToRequestTypes acts [] rs) 5)
--- #print genCedarExpr
--- Uncomment this line to see the output from the generator for Cedar expressions
-#eval Gen.printSamples (genCedarExpr 5)
+
+def genSchemaThenCedarExpr (fuel : Nat) : Gen (CedarExpr) := do
+  let ns := [EntityName.MkName "EntityType1" [], EntityName.MkName "EntityType2" []]
+  -- 1. Generate wf_Schema xs
+  let xs ← ArbitrarySizedSuchThat.arbitrarySizedST (fun s => WfSchema ns s) fuel
+  match xs with
+  -- 2. Generate requestTypes rs from it
+  | Schema.MkSchema ets acts => do
+    let reqso ← ArbitrarySizedSuchThat.arbitrarySizedST (fun rs => ActionSchemaToRequestTypes acts [] rs) fuel
+    -- 3. Generate environments es from rs and xs
+    match reqso with
+    | reqs => do
+      let envso ← ArbitrarySizedSuchThat.arbitrarySizedST (fun es => SchemaToEnvironments (Schema.MkSchema ets acts) reqs es) fuel
+      -- 4. Generate a well-typed expression from v, the head of es
+      match envso with
+      | v :: _ => do
+        let eps ← ArbitrarySizedSuchThat.arbitrarySizedST (fun e => HasType (.somepaths []) v e (.boolType .anyBool)) fuel
+        match eps with
+        | (expr, _) => return expr
+      | _ => throw Gen.genericFailure
+
+#guard_msgs(drop info) in
+#eval Gen.printSamples (genCedarExpr 2)
+
+#guard_msgs(drop info) in
+#eval Gen.printSamples (genSchemaThenCedarExpr 3)

--- a/Test/DeriveArbitrarySuchThat/WithUnfolds.lean
+++ b/Test/DeriveArbitrarySuchThat/WithUnfolds.lean
@@ -13,14 +13,19 @@ opaque SomeFoo : TypeBox
 def five := 5
 
 inductive TypeBoxPred : Nat → Prop where
-| someRefl {x : NatFoo.ty} : x = x → TypeBoxPred five
+| someRefl {x : NatFoo.ty} : x = x → TypeBoxPred 5
+
+inductive TypeBoxPredS : String → Prop where
+| someRefl {x : NatFoo.ty} : x = x → TypeBoxPredS "lol"
 
 inductive TypeBoxPred' : Nat → Prop where
 | someRefl {x : SomeFoo.ty} : x = x → TypeBoxPred' five
 
-#guard_msgs(error, drop warning, drop info) in
+#guard_msgs(error, drop info, drop warning) in
 #derive_generator (fun (n : Nat) => TypeBoxPred n)
 
-/-- error: exprToHypothesisExpr: unable to convert SomeFoo.1 to a HypothesisExpr, must be a constructor or an inductive applied to arguments. -/
-#guard_msgs(error, drop warning, drop info) in
+#guard_msgs(error, drop info, drop warning) in
+#derive_generator (fun (n : _) => TypeBoxPredS n)
+
+#guard_msgs(drop error, drop warning, drop info) in
 #derive_generator (fun (n : Nat) => TypeBoxPred' n)

--- a/Test/DeriveArbitrarySuchThat/WithUnfolds.lean
+++ b/Test/DeriveArbitrarySuchThat/WithUnfolds.lean
@@ -12,15 +12,39 @@ opaque SomeFoo : TypeBox
 
 def five := 5
 
+--
 inductive TypeBoxPred : Nat → Prop where
-| someRefl {x : NatFoo.ty} : x = x → TypeBoxPred 5
+| someRefl {x : NatFoo.ty} : x = x → 0 = x → 5 = 5 → TypeBoxPred 5
 
 inductive TypeBoxPredS : String → Prop where
-| someRefl {x : NatFoo.ty} : x = x → TypeBoxPredS "lol"
+| someRefl {x : NatFoo.ty} y : x = x → y = "foo" → TypeBoxPredS "foo"
 
 inductive TypeBoxPred' : Nat → Prop where
 | someRefl {x : SomeFoo.ty} : x = x → TypeBoxPred' five
 
+instance (α : Type) (n : Nat) [OfNat α n] : ArbitrarySizedSuchThat α (fun x => OfNat.ofNat n = x) where
+  arbitrarySizedST _ := return OfNat.ofNat n
+
+/--
+error: failed to synthesize
+  ArbitrarySizedSuchThat Nat fun x => OfNat.ofNat 0 = x
+
+Hint: Additional diagnostic information may be available using the `set_option diagnostics true` command.-/
+#guard_msgs(all) in
+#check ArbitrarySizedSuchThat.arbitrarySizedST (fun (x : Nat) => Eq (OfNat.ofNat 0) x)
+
+
+/--
+error: failed to synthesize
+  ArbitrarySizedSuchThat NatFoo.ty fun x => OfNat.ofNat 0 = x
+
+Hint: Additional diagnostic information may be available using the `set_option diagnostics true` command.
+---
+error: failed to synthesize
+  ArbitrarySizedSuchThat NatFoo.ty fun x => OfNat.ofNat 0 = x
+
+Hint: Additional diagnostic information may be available using the `set_option diagnostics true` command.
+-/
 #guard_msgs(error, drop info, drop warning) in
 #derive_generator (fun (n : Nat) => TypeBoxPred n)
 


### PR DESCRIPTION
A schedule is essentially a permutation of hypotheses. Each hypothesis constrains a set of variables. The goal of a schedule is to instantiate all variables across all hypotheses in ways which guarantee that they satisfy the hypotheses' constraints. A variable can be constrained by multiple hypotheses, but each variable can only be instantiated to satisfy a single hypothesis (turning it into a fixed input for the rest of the hypotheses that constrain it). If all variables constrained by a hypothesis are fixed before the hypothesis is used to instantiate one or more of its variables, that hypothesis must be checked, which often makes for a bad generator schedule. 

Therefore, when two hypotheses share a variable, there is a dependence between them; whichever goes first in a schedule gets to instantiate the variable, and the other must treat it as an arbitrary fixed value. This dependence extends transitively (though this is an over-approximation, we really only care about orderings between hypotheses directly connected).

If there is no transitive dependency path between two hypotheses, the order they appear in should not matter, so we can fix their order in all schedules. Generally, the transitive dependency gives us simply connected components of the dependency graph, and we only have to permute within simply connected components, while keeping distinct SCCs in a fixed order. 

This PR performs this optimization, providing a dramatic reduction in the size of the enumeration of schedules we have to consider in our analysis.

This PR additionally provides support for use of literals (numbers and strings) in inductives we analyze, which was previously unsupported.

Finally, this PR fixes #16 by deduplicating variables in a hypothesis's variable set prior to enumeration.