### PR TITLE
chore: Add some namespaces to help avoid polluting imports.

### DIFF
--- a/Plausible/Chamelean/DeriveChecker.lean
+++ b/Plausible/Chamelean/DeriveChecker.lean
@@ -7,7 +7,7 @@ import Plausible.Chamelean.DecOpt
 import Plausible.Chamelean.UnificationMonad
 
 open Lean Std Elab Command Meta Term Parser
-open Idents
+open Idents Schedules
 
 
 
@@ -140,8 +140,8 @@ def deriveScheduledChecker (inductiveProp : TSyntax `term) : CommandElabM (TSynt
           -- This is all done in a state monad: when we detect that a new instance is required, we append it to an array of `TSyntax term`s
           -- (where each term represents a typeclass instance)
           let (subChecker, instances) ← StateT.run (s := #[]) (do
-            let mexp ← scheduleToMExp schedule (.MId `size) (.MId `initSize) unifyState.outputType
-            mexpToTSyntax mexp (deriveSort := .Checker))
+            let mexp ← MExp.scheduleToMExp schedule (.MId `size) (.MId `initSize) unifyState.outputType
+            MExp.mexpToTSyntax mexp (deriveSort := .Checker))
 
           requiredInstances := requiredInstances ++ instances
 

--- a/Plausible/Chamelean/DeriveConstrainedProducer.lean
+++ b/Plausible/Chamelean/DeriveConstrainedProducer.lean
@@ -16,7 +16,7 @@ import Lean.Elab.Command
 import Lean.Meta.Basic
 
 open Lean Elab Command Meta Term Parser
-open Idents
+open Idents Schedules
 
 
 ----------------------------------------------------------------------------------------------------------------------------------
@@ -606,8 +606,8 @@ def deriveConstrainedProducer (outputVar : Ident) (outputTypeSyntax : TSyntax `t
           -- This is all done in a state monad: when we detect that a new instance is required, we append it to an array of `TSyntax term`s
           -- (where each term represents a typeclass instance)
           let (subProducer, instances) ← StateT.run (s := #[]) (do
-            let mexp ← scheduleToMExp schedule (.MId `size) (.MId `initSize) outputType
-            mexpToTSyntax mexp deriveSort)
+            let mexp ← MExp.scheduleToMExp schedule (.MId `size) (.MId `initSize) outputType
+            MExp.mexpToTSyntax mexp deriveSort)
 
           requiredInstances := requiredInstances ++ instances
 

--- a/Plausible/Chamelean/DeriveSchedules.lean
+++ b/Plausible/Chamelean/DeriveSchedules.lean
@@ -7,8 +7,10 @@ import Plausible.Chamelean.MakeConstrainedProducerInstance
 import Plausible.Chamelean.LazyList
 import Lean.Util.SCC
 
+namespace Schedules
 
 open Lean Meta
+open Schedules
 
 -- Adapted from QuickChick source code
 -- https://github.com/QuickChick/QuickChick/blob/internal-rewrite/plugin/newGenericLib.ml

--- a/Plausible/Chamelean/MExp.lean
+++ b/Plausible/Chamelean/MExp.lean
@@ -9,8 +9,10 @@ import Plausible.Chamelean.UnificationMonad
 import Plausible.Chamelean.Idents
 import Plausible.Chamelean.Utils
 
+namespace MExp
+
 open Plausible
-open Idents
+open Idents Schedules
 open Lean Parser Elab Term Command ToExpr TSyntax
 
 -- Adapted from QuickChick source code

--- a/Plausible/Chamelean/MakeConstrainedProducerInstance.lean
+++ b/Plausible/Chamelean/MakeConstrainedProducerInstance.lean
@@ -9,7 +9,7 @@ import Plausible.Chamelean.Schedules
 
 
 open Lean Elab Command Meta Term Parser Std
-open Idents
+open Idents Schedules
 
 /-- Extracts the name of the induction relation and its arguments -/
 def parseInductiveApp (body : Term) : CommandElabM (TSyntax `ident × TSyntaxArray `ident) := do

--- a/Plausible/Chamelean/Schedules.lean
+++ b/Plausible/Chamelean/Schedules.lean
@@ -3,6 +3,8 @@ import Plausible.Chamelean.Utils
 
 open Lean
 
+
+namespace Schedules
 ----------------------------------------------
 -- Type definitions
 ----------------------------------------------
@@ -246,3 +248,5 @@ def addConclusionPatternsAndEqualitiesToSchedule (patterns : List (Unknown × Pa
   let matchSteps := (Function.uncurry ScheduleStep.Match) <$> patterns
   let equalityCheckSteps := (fun (u1, u2) => ScheduleStep.Check (Source.NonRec (`BEq.beq, [.Unknown u1, .Unknown u2])) true) <$> equalities.toList
   (matchSteps ++ equalityCheckSteps ++ existingScheduleSteps, scheduleSort)
+
+end Schedules


### PR DESCRIPTION
This is still imperfect, since there are still a bunch of top-level definitions, but it should help.