### PR TITLE
feat: Partial Order Reduction Major Improvement

### DIFF
--- a/Plausible/Chamelean/DeriveConstrainedProducer.lean
+++ b/Plausible/Chamelean/DeriveConstrainedProducer.lean
@@ -157,8 +157,7 @@ partial def convertExprToRangeInCurrentContext (e : Expr) : UnifyM Range := do
       match e with
       | .const u _ => return (.Unknown u)
       | .lit literal => return .Lit literal
-      | _ => return .Fixed
-      -- | _ => throwError m!"Cannot convert expression {e} to Range"
+      | _ => throwError m!"Cannot convert expression {e} to Range"
 
 /-- Converts a hypothesis (reprented as a `TSyntax term`) to a `Range` -/
 partial def convertHypothesisTermToRange (term : TSyntax `term) : UnifyM Range := do
@@ -383,7 +382,7 @@ def getScheduleForInductiveRelationConstructor
           try convertHypothesisTermToRange hypTerm
           catch _ => convertExprToRangeInCurrentContext hyp
 
-        -- Convert each hypotahesis' range to a `HypothesisExpr`, which is just a constructor application
+        -- Convert each hypothesis' range to a `HypothesisExpr`, which is just a constructor application
         -- (constructor name applied to some list of arguments, which are themselves `ConstructorExpr`s)
         hypothesisExprs := hypothesisExprs.push (← convertRangeToCtorAppForm hypRange)
 

--- a/Plausible/Chamelean/DeriveConstrainedProducer.lean
+++ b/Plausible/Chamelean/DeriveConstrainedProducer.lean
@@ -157,7 +157,8 @@ partial def convertExprToRangeInCurrentContext (e : Expr) : UnifyM Range := do
       match e with
       | .const u _ => return (.Unknown u)
       | .lit literal => return .Lit literal
-      | _ => throwError m!"Cannot convert expression {e} to Range"
+      | _ => return .Fixed
+      -- | _ => throwError m!"Cannot convert expression {e} to Range"
 
 /-- Converts a hypothesis (reprented as a `TSyntax term`) to a `Range` -/
 partial def convertHypothesisTermToRange (term : TSyntax `term) : UnifyM Range := do
@@ -382,7 +383,7 @@ def getScheduleForInductiveRelationConstructor
           try convertHypothesisTermToRange hypTerm
           catch _ => convertExprToRangeInCurrentContext hyp
 
-        -- Convert each hypothesis' range to a `HypothesisExpr`, which is just a constructor application
+        -- Convert each hypotahesis' range to a `HypothesisExpr`, which is just a constructor application
         -- (constructor name applied to some list of arguments, which are themselves `ConstructorExpr`s)
         hypothesisExprs := hypothesisExprs.push (← convertRangeToCtorAppForm hypRange)
 
@@ -484,6 +485,8 @@ def getScheduleForInductiveRelationConstructor
 
       let prefixSize := 100000
 
+      trace[plausible.deriving.arbitrary] m!"First Schedule: {scheduleStepsToString bestSchedule} \nChecks & Length: {(minChecks, minLen)} \nSchedules Considered: {repr countSeen}"
+
       for schdM in LazyList.take prefixSize rest.get do
         let schd ← schdM
         let checkCount := countChecks schd
@@ -493,6 +496,8 @@ def getScheduleForInductiveRelationConstructor
           bestSchedule := schd
           minChecks := checkCount
           minLen := len
+          trace[plausible.deriving.arbitrary] m!"Better Schedule: {scheduleStepsToString bestSchedule} \nChecks & Length: {(minChecks, minLen)} \nSchedules Considered: {repr countSeen}"
+
 
       trace[plausible.deriving.arbitrary] m!"Chosen Schedule: {scheduleStepsToString bestSchedule} \nChecks & Length: {(minChecks, minLen)} \nSchedules Considered: {repr countSeen}"
 

--- a/Plausible/Chamelean/LazyList.lean
+++ b/Plausible/Chamelean/LazyList.lean
@@ -168,6 +168,7 @@ def lazySeq (s : α → α) (lo : α) (len : Nat) : LazyList α :=
     | .succ remaining' => .lcons current (Thunk.mk $ fun _ => go (s current) remaining')
   go lo len
 
+/-- Creates a lazy sequence from 0 to n built lazily. -/
 def range (n : Nat) : LazyList Nat :=
   lazySeq .succ .zero n
 

--- a/Plausible/Chamelean/LazyList.lean
+++ b/Plausible/Chamelean/LazyList.lean
@@ -31,6 +31,10 @@ def toListAux (acc : List α) : LazyList α → List α
 def toList (l : LazyList α) : List α :=
   toListAux [] l
 
+/-- Converts a `List` into a `LazyList`-/
+def fromList (l : List α) : LazyList α :=
+  l.foldr (fun a acc => .lcons a ⟨fun _ => acc⟩) .lnil
+
 /-- We pretty-print `LazyList`s by converting them to ordinary lists
     (forcing all the thunks) & pretty-printing the resultant list. -/
 instance [Repr α] : Repr (LazyList α) where
@@ -163,5 +167,8 @@ def lazySeq (s : α → α) (lo : α) (len : Nat) : LazyList α :=
     | .zero => .lnil
     | .succ remaining' => .lcons current (Thunk.mk $ fun _ => go (s current) remaining')
   go lo len
+
+def range (n : Nat) : LazyList Nat :=
+  lazySeq .succ .zero n
 
 end LazyList

--- a/Plausible/Chamelean/Schedules.lean
+++ b/Plausible/Chamelean/Schedules.lean
@@ -94,13 +94,15 @@ def sourceToString source := match source with
   | Source.Rec name ctrArgs => s!"{ToExpr.toExpr (name,ctrArgs)}"
   | Source.NonRec hyp => s!"{ToExpr.toExpr hyp}"
 
+def patternToString pat := s!"{ToExpr.toExpr $ constructorExprOfPattern pat}"
+
 /-- Stringifier for `step` -/
 def stepToString step := match step with
     | ScheduleStep.Unconstrained name src _ => s!"{name} ← {sourceToString src}"
     | .SuchThat vars src _ => s!"{vars.map (fun ((name : Name), (_ : Option ConstructorExpr)) => name)} ← {sourceToString src}"
     | .Check src true => s!"check {sourceToString src}"
     | .Check src false => s!"check ¬{sourceToString src}"
-    | .Match name pattern => s!"match {name} with {repr pattern}"
+    | .Match name pattern => s!"match {name} with {patternToString pattern}"
 
 /-- Stringifier for lists of steps. -/
 def scheduleStepsToString (steps : List ScheduleStep) := "do\n  " ++ String.intercalate "\n  " (stepToString <$> steps)


### PR DESCRIPTION
Responds to #19 by using partial order reduction to not enumerate redundant generator hypothesis schedules. The order of two hypotheses is only considered if the hypotheses share one or more variables.

For example, if we had hypotheses `H : {a}`, `I : {a,b}`, and `J : {b}` then previously we would consider all 6 permutations of the three hypotheses. But, for instance, the schedules `HJI` and `JHI` are indistinguishable because `J` and `H` do not share any variables and are consecutive in the schedules. This is similarly true for `IHJ` and `IJH`. The new enumeration only includes a single representative from each equivalence class of indistinguishable schedules.

So we only get the schedules: `HIJ, JIH, HJI, IHJ`.

Another major reduction comes from disallowing a hypothesis outputting no variables if it has any it could theoretically output. Previously, if the hypotheses `H a` appeared, we would include both `a <- H a` and `a <- arbitrary; check H` as enumerated schedules. Now we only allow the former.