### PR TITLE
feat: Change the syntax of the front end

### DIFF
--- a/Plausible/Chamelean/DeriveEnum.lean
+++ b/Plausible/Chamelean/DeriveEnum.lean
@@ -141,13 +141,13 @@ def mkEnumSizedInstance (targetTypeName : Name) : CommandElabM (TSyntax `command
           $matchExpr
       fun $freshSizeIdent => $auxEnumFn $freshSizeIdent)
 
-syntax (name := derive_enum) "#derive_enum" term : command
+syntax (name := enum_deriver) "derive_enum" term : command
 
 /-- Command elaborator which derives an instance of the `EnumSized` typeclass -/
-@[command_elab derive_enum]
+@[command_elab enum_deriver]
 def elabDeriveEnum : CommandElab := fun stx => do
   match stx with
-  | `(#derive_enum $targetTypeTerm:term) => do
+  | `(derive_enum $targetTypeTerm:term) => do
 
     -- TODO: figure out how to support parameterized types
     let targetTypeIdent ←

--- a/README.md
+++ b/README.md
@@ -50,11 +50,11 @@ We provide two commands for deriving constrained generators/enumerators. For exa
 support we want to derive constrained producers of `Tree`s satisfying some inductive relation `balanced n t` (height-`n` trees that are `balanced`. To do so, the user would write:
 
 ```lean
--- `#derive_generator` & `#derive_enumerator` derive constrained generators/enumerators 
+-- `derive_generator` & `derive_enumerator` derive constrained generators/enumerators 
 -- for `Tree`s that are balanced at some height `n`,
 -- where `balanced n t` is a user-defined inductive relation
-#derive_generator (fun (t : Tree) => balanced n t) 
-#derive_enumerator (fun (t : Tree) => balanced n t)
+derive_generator (fun n => ∃ t, balanced n t) 
+derive_enumerator (fun n => ∃ t, balanced n t)
 ```
 To sample from the derived producer, users invoke `runSizedGen` / `runSizedEnum` & specify the right 
 instance of the `ArbitrarySizedSuchThat` / `EnumSizedSuchThat` typeclass (along with some `Nat` to act as the generator size):
@@ -68,25 +68,25 @@ instance of the `ArbitrarySizedSuchThat` / `EnumSizedSuchThat` typeclass (along 
 #eval runSizedEnum (EnumSizedSuchThat.enumSizedST (fun t => balanced 5 t)) 3
 ```
 
-Some extra details about the grammar of the lambda-abstraction that is passed to `#derive_generator` / `#derive_enumerator`:
+Some extra details about the grammar of the lambda-abstraction that is passed to `derive_generator` / `derive_enumerator`:
 
 Specifically: in the command
 ```lean
-#derive_generator (fun (x : t) => P x1 ... x .... xn)
+derive_generator (fun x1 ... xn => ∃ x, P x1 ... x ... xn)
 ```
-`P` must be an inductively defined relation, `x` is the value to be generated (the type annotation on `x` is required), and `x1 ... xn` are (implicitly universally quantified) variable names. Following QuickChick, we expect `x1, ..., xn` to be variable names (we don't support literals in the position of the `xi` currently). 
+`P` must be an inductively defined relation, `x` is the value to be generated (bound by `∃`), and `x1 ... xn` are variable names bound by the `fun`. Following QuickChick, we expect `x1, ..., xn` to be variable names (we don't support literals in the position of the `xi` currently). 
 
 **3. Deriving checkers (partial decision procedures)** (for inductive relations)                                 
 A checker for an inductively-defined `Prop` is a `Nat -> Option Bool` function, which 
 takes a `Nat` argument as fuel and returns `none` if it can't decide whether the `Prop` holds (e.g. it runs out of fuel),
 and otherwise returns `some true/some false` depending on whether the `Prop` holds.
 
-We provide a command elaborator which elaborates the `#derive_checker` command:
+We provide a command elaborator which elaborates the `derive_checker` command:
 
 ```lean
--- `#derive_checker` derives a checker which determines whether `Tree`s `t` 
+-- `derive_checker` derives a checker which determines whether `Tree`s `t` 
 -- satisfy the `balanced` inductive relation mentioned above 
-#derive_checker (balanced n t)
+derive_checker (fun n t => balanced n t)
 ```
 
 ## Repo overview
@@ -135,7 +135,7 @@ We provide a command elaborator which elaborates the `#derive_checker` command:
 
 ### Tests
 **Overview of snapshot test corpus**:
-- The [`Test`](./Test/) subdirectory contains [snapshot tests](https://www.cs.cornell.edu/~asampson/blog/turnt.html) (aka [expect tests](https://blog.janestreet.com/the-joy-of-expect-tests/)) for the `#derive_generator` & `#derive_arbitrary` command elaborators. 
+- The [`Test`](./Test/) subdirectory contains [snapshot tests](https://www.cs.cornell.edu/~asampson/blog/turnt.html) (aka [expect tests](https://blog.janestreet.com/the-joy-of-expect-tests/)) for the `derive_generator` & `derive_arbitrary` command elaborators. 
 - Run `lake test` to check that the derived generators in [`Test`](./Test/) typecheck, and that the code for the derived generators match the expected output.
 - See [`DeriveBSTGenerator.lean`](./Test/DeriveArbitrarySuchThat/DeriveBSTGenerator.lean) & [`DeriveBalancedTreeGenerator.lean`](./Test/DeriveArbitrarySuchThat/DeriveBalancedTreeGenerator.lean) for examples of snapshot tests. Follow the template in these two files to add new snapshot test file, and remember to import the new test file in [`Test.lean`](./Test.lean) afterwards.
 
@@ -148,7 +148,7 @@ We provide a command elaborator which elaborates the `#derive_checker` command:
 - [`CedarCheckerGenerators.lean`](./Test/CedarExample/CedarCheckerGenerators.lean): Snapshot tests for derived checkers & generators for Cedar terms / types / schemas 
 - [`CedarWellTypedTermGenerator.lean`](./Test/CedarExample/CedarWellTypedTermGenerator.lean): Example generator for well-typed Cedar expressions
 
-**Tests for Unconstrained Generators (`#derive_arbitrary`)**:
+**Tests for Unconstrained Generators (`derive_arbitrary`)**:
 - [`BitVecStructureTest.lean`](./Test/DeriveArbitrary/BitVecStructureTest.lean): Tests for structures with dependently-typed `BitVec` arguments
 - [`DeriveNKIBinopGenerator.lean`](./Test/DeriveArbitrary/DeriveNKIBinopGenerator.lean): Derived generator for NKI binary operators (logical, comparison, arithmetic, bitwise)
 - [`DeriveNKIValueGenerator.lean`](./Test/DeriveArbitrary/DeriveNKIValueGenerator.lean): Derived generator for NKI value types (none, bool, int, string, tensor, etc.)
@@ -160,7 +160,7 @@ We provide a command elaborator which elaborates the `#derive_checker` command:
 - [`ParameterizedTypeTest.lean`](./Test/DeriveArbitrary/ParameterizedTypeTest.lean): Derived generator for parameterized types (polymorphic `MyList`)
 - [`StructureTest.lean`](./Test/DeriveArbitrary/StructureTest.lean): Derived generator for structures with named fields
 
-**Tests for Constrained Generators (`#derive_generator`)**:
+**Tests for Constrained Generators (`derive_generator`)**:
 - [`DeriveBSTGenerator.lean`](./Test/DeriveArbitrarySuchThat/DeriveBSTGenerator.lean): Derived generator for Binary Search Trees (with a BST insertion property-based test)
 - [`DeriveBalancedTreeGenerator.lean`](./Test/DeriveArbitrarySuchThat/DeriveBalancedTreeGenerator.lean): Derived generator for balanced binary trees
 - [`DerivePermutationGenerator.lean`](./Test/DeriveArbitrarySuchThat/DerivePermutationGenerator.lean): Derived generator for list permutations
@@ -171,7 +171,7 @@ We provide a command elaborator which elaborates the `#derive_checker` command:
 - [`NonLinearPatternsTest.lean`](./Test/DeriveArbitrarySuchThat/NonLinearPatternsTest.lean): Tests for relations with non-linear patterns (repeated variables)
 - [`SimultaneousMatchingTests.lean`](./Test/DeriveArbitrarySuchThat/SimultaneousMatchingTests.lean): Tests for relations with simultaneous pattern matching on multiple inputs
 
-**Tests for Checkers (`#derive_checker`)**:
+**Tests for Checkers (`derive_checker`)**:
 - [`DeriveBSTChecker.lean`](./Test/DeriveDecOpt/DeriveBSTChecker.lean): derived checker for BSTs
 - [`DeriveBalancedTreeChecker.lean`](./Test/DeriveDecOpt/DeriveBalancedTreeChecker.lean): derived checker for balanced trees
 - [`DerivePermutationChecker.lean`](./Test/DeriveDecOpt/DerivePermutationChecker.lean): derived checker for list permutations
@@ -182,7 +182,7 @@ We provide a command elaborator which elaborates the `#derive_checker` command:
 - [`NonLinearPatternsTest.lean`](./Test/DeriveDecOpt/NonLinearPatternsTest.lean): Tests for derived checker with non-linear patterns
 - [`SimultaneousMatchingTests.lean`](./Test/DeriveDecOpt/SimultaneousMatchingTests.lean): Derived checker for inductive relations which require matching on multiple inputs
 
-**Tests for Unconstrained Enumerators (`#derive_enum`)**:
+**Tests for Unconstrained Enumerators (`derive_enum`)**:
 - [`BitVecStructureTest.lean`](./Test/DeriveEnum/BitVecStructureTest.lean): Derived enumerators for structures with `BitVec` arguments
 - [`DeriveNKIBinopEnumerator.lean`](./Test/DeriveEnum/DeriveNKIBinopEnumerator.lean): Derived enumerators for binary operators in the [NKI language](https://github.com/leanprover/KLR/blob/main/KLR/NKI/Basic.lean)
 - [`DeriveNKIValueEnumerator.lean`](./Test/DeriveEnum/DeriveNKIValueEnumerator.lean): Derived enumerators for value types in the [NKI language](https://github.com/leanprover/KLR/blob/main/KLR/NKI/Basic.lean)
@@ -191,7 +191,7 @@ We provide a command elaborator which elaborates the `#derive_checker` command:
 - [`DeriveTreeEnumerator.lean`](./Test/DeriveEnum/DeriveTreeEnumerator.lean): Derived enumerators for binary trees
 - [`StructureTest.lean`](./Test/DeriveEnum/StructureTest.lean): Derived enumerators for structures with named fields
 
-**Tests for Constrained Enumerators (`#derive_enumerator`)**:
+**Tests for Constrained Enumerators (`derive_enumerator`)**:
 - [`DeriveBSTEnumerator.lean`](./Test/DeriveEnumSuchThat/DeriveBSTEnumerator.lean): Derived enumerators for Binary Search Trees
 - [`DeriveBalancedTreeEnumerator.lean`](./Test/DeriveEnumSuchThat/DeriveBalancedTreeEnumerator.lean): Derived enumerators for balanced trees
 - [`DerivePermutationEnumerator.lean`](./Test/DeriveEnumSuchThat/DerivePermutationEnumerator.lean): Derived enumerators for permutations

--- a/Test/CedarExample/CedarCheckerGenerators.lean
+++ b/Test/CedarExample/CedarCheckerGenerators.lean
@@ -83,233 +83,233 @@ deriving instance DecidableEq for PathSet
 --------------------------------------------------
 
 #guard_msgs(drop info, drop warning) in
-#derive_checker (Cedar.RecordExpr ce)
+derive_checker (fun ce => Cedar.RecordExpr ce)
 
 #guard_msgs(drop info, drop warning) in
-#derive_generator (fun (ce : CedarExpr) => Cedar.RecordExpr ce)
+derive_generator ∃ (ce : CedarExpr), Cedar.RecordExpr ce
 
 #guard_msgs(drop info, drop warning) in
-#derive_checker (Cedar.DefinedName · ·)
+derive_checker (Cedar.DefinedName · ·)
 
 #guard_msgs(drop info, drop warning) in
-#derive_checker (Cedar.WfCedarType n r)
+derive_checker (fun n r => Cedar.WfCedarType n r)
 
 #guard_msgs(drop info, drop warning) in
-#derive_generator (fun (ns_1_1 : List EntityName) => Cedar.DefinedName ns_1_1 n)
+derive_generator fun n => ∃ (ns_1_1 : List EntityName), Cedar.DefinedName ns_1_1 n
 
 #guard_msgs(drop info, drop warning) in
-#derive_generator (fun (ns_1 : _) => Cedar.WfCedarType ns_1 r)
+derive_generator fun r => ∃ ns_1, Cedar.WfCedarType ns_1 r
 
 #guard_msgs(drop info, drop warning) in
-#derive_generator (fun (ns_1 : List EntityName) => Cedar.WfRecordType ns_1 r)
+derive_generator fun r => ∃ (ns_1 : List EntityName), Cedar.WfRecordType ns_1 r
 
 #guard_msgs(drop info, drop warning) in
-#derive_checker (Cedar.WfRecordType n r)
+derive_checker (fun n r => Cedar.WfRecordType n r)
 
 #guard_msgs(drop info, drop warning) in
-#derive_checker (Cedar.BindAttrType ns TE t)
+derive_checker fun ns TE t => Cedar.BindAttrType ns TE t
 
 #guard_msgs(drop info, drop warning) in
-#derive_generator (fun (ns : _) => Cedar.BindAttrType ns TE t_1)
+derive_generator fun TE t_1 => ∃ (ns : _), Cedar.BindAttrType ns TE t_1
 
 #guard_msgs(drop info, drop warning) in
-#derive_generator (fun (E : _) => Cedar.LookupEntityAttr E (fn, b) t_1_1)
+derive_generator (fun p t_1_1 => ∃ E, Cedar.LookupEntityAttr E p t_1_1)
 
 #guard_msgs(drop info, drop warning) in
-#derive_generator (fun (ets : _) => Cedar.GetEntityAttr ets n t_1)
+derive_generator (fun n t_1 => ∃ (ets : _), Cedar.GetEntityAttr ets n t_1)
 
 #guard_msgs(drop info, drop warning) in
-#derive_checker (Cedar.SetExpr ce)
+derive_checker (fun ce => Cedar.SetExpr ce)
 
 #guard_msgs(drop info, drop warning) in
-#derive_generator (fun (ce : CedarExpr) => Cedar.SetExpr ce)
+derive_generator ∃ (ce : CedarExpr), Cedar.SetExpr ce
 
 set_option maxHeartbeats 2000000
 
 #guard_msgs(drop info, drop warning) in
-#derive_checker (Cedar.SetEntityValues ce)
+derive_checker (fun ce => Cedar.SetEntityValues ce)
 
 #guard_msgs(drop info, drop warning) in
-#derive_generator (fun (ce : CedarExpr) => Cedar.SetEntityValues ce)
+derive_generator ∃ (ce : CedarExpr), Cedar.SetEntityValues ce
 
 #guard_msgs(drop info, drop warning) in
-#derive_generator (fun (rs_1_1 : _) => Cedar.ActionToRequestTypes uid_1 p rs c l_1_1 rs_1_1)
+derive_generator (fun uid_1 p rs c l_1_1 => ∃ (rs_1_1 : _), Cedar.ActionToRequestTypes uid_1 p rs c l_1_1 rs_1_1)
 
 #guard_msgs(drop info, drop warning) in
-#derive_checker (Cedar.DefinedName ns n)
+derive_checker (fun ns n => Cedar.DefinedName ns n)
 
 #guard_msgs(drop info, drop warning) in
-#derive_generator (fun (n : EntityName) => Cedar.DefinedName ns n)
+derive_generator (fun ns => ∃ (n : EntityName), Cedar.DefinedName ns n)
 
 --------------------------------------------------
 -- Checker & Generator for `DefinedNames` relation
 --------------------------------------------------
 
 #guard_msgs(drop info, drop warning) in
-#derive_checker (Cedar.DefinedNames ns ns0)
+derive_checker (fun ns ns0 => Cedar.DefinedNames ns ns0)
 
 #guard_msgs(drop info, drop warning) in
-#derive_generator (fun (ns0 : List EntityName) => Cedar.DefinedNames ns ns0)
+derive_generator (fun ns => ∃ (ns0 : List EntityName), Cedar.DefinedNames ns ns0)
 
 --------------------------------------------------
 -- Checker & Generator for well-formed Cedar types
 --------------------------------------------------
 
 #guard_msgs(drop info, drop warning) in
-#derive_checker (Cedar.WfCedarType ns ct)
+derive_checker (fun ns ct => Cedar.WfCedarType ns ct)
 
 #guard_msgs(drop info, drop warning) in
-#derive_generator (fun (ct : CedarType) => Cedar.WfCedarType ns ct)
+derive_generator (fun ns => ∃ (ct : CedarType), Cedar.WfCedarType ns ct)
 
 ----------------------------------------------------
 -- Checker & Generator for well-formed record types
 ----------------------------------------------------
 
 #guard_msgs(drop info, drop warning) in
-#derive_checker (Cedar.WfRecordType ns rt)
+derive_checker (fun ns rt => Cedar.WfRecordType ns rt)
 
 #guard_msgs(drop info, drop warning) in
-#derive_generator (fun (rt : CedarType) => Cedar.WfRecordType ns rt)
+derive_generator (fun ns => ∃ (rt : CedarType), Cedar.WfRecordType ns rt)
 
 ----------------------------------------------------
 -- Checker & Generator for well-formed attributes
 ----------------------------------------------------
 
 #guard_msgs(drop info, drop warning) in
-#derive_checker (Cedar.WfAttrs ns attrs)
+derive_checker (fun ns attrs => Cedar.WfAttrs ns attrs)
 
 #guard_msgs(drop info, drop warning) in
-#derive_generator (fun (attrs : List (String × Bool × CedarType)) => Cedar.WfAttrs ns attrs)
+derive_generator (fun ns => ∃ (attrs : List (String × Bool × CedarType)), Cedar.WfAttrs ns attrs)
 
 ---------------------------------------------------------------------
 -- Checker & Generator for well-formed `EntitySchemaEntry`(ies)
 ---------------------------------------------------------------------
 
 #guard_msgs(drop info, drop warning) in
-#derive_checker (Cedar.WfET ns et)
+derive_checker (fun ns et => Cedar.WfET ns et)
 
 #guard_msgs(drop info, drop warning) in
-#derive_generator (fun (et : EntitySchemaEntry) => Cedar.WfET ns et)
+derive_generator (fun ns => ∃ (et : EntitySchemaEntry), Cedar.WfET ns et)
 
 #guard_msgs(drop info, drop warning) in
-#derive_checker (Cedar.WfETS ns ns0 ets)
+derive_checker (fun ns ns0 ets => Cedar.WfETS ns ns0 ets)
 
 #guard_msgs(drop info, drop warning) in
-#derive_generator (fun (ets : List (EntityName × EntitySchemaEntry)) => Cedar.WfETS ns ns0 ets)
+derive_generator (fun ns ns0 => ∃ (ets : List (EntityName × EntitySchemaEntry)), Cedar.WfETS ns ns0 ets)
 
 ---------------------------------------------------------------------
 -- Checker & Generator for well-formed `ActionSchemaEntry`(ies)
 ---------------------------------------------------------------------
 
 #guard_msgs(drop info, drop warning) in
-#derive_checker (Cedar.WfACT ns act)
+derive_checker (fun ns act => Cedar.WfACT ns act)
 
 #guard_msgs(drop info, drop warning) in
-#derive_generator (fun (act : EntityUID × ActionSchemaEntry) => Cedar.WfACT ns act)
+derive_generator (fun ns => ∃ (act : EntityUID × ActionSchemaEntry), Cedar.WfACT ns act)
 
 #guard_msgs(drop info, drop warning) in
-#derive_checker (Cedar.WfACTS ns act)
+derive_checker (fun ns act => Cedar.WfACTS ns act)
 
 #guard_msgs(drop info, drop warning) in
-#derive_generator (fun (act : List (EntityUID × ActionSchemaEntry)) => Cedar.WfACTS ns act)
+derive_generator (fun ns => ∃ (act : List (EntityUID × ActionSchemaEntry)), Cedar.WfACTS ns act)
 
 ------------------------------------------------------------
 -- Checker & Generator for well-formed schemas
 ------------------------------------------------------------
 
 #guard_msgs(drop info, drop warning) in
-#derive_checker (Cedar.WfSchema ns s)
+derive_checker (fun ns s => Cedar.WfSchema ns s)
 
 #guard_msgs(drop info, drop warning) in
-#derive_generator (fun (s : Schema) => Cedar.WfSchema ns s)
+derive_generator (fun ns => ∃ (s : Schema), Cedar.WfSchema ns s)
 
 ------------------------------------------------------------
 -- Checker & Generator for defined entities
 ------------------------------------------------------------
 
 #guard_msgs(drop info, drop warning) in
-#derive_checker (Cedar.DefinedEntity ets n)
+derive_checker (fun ets n => Cedar.DefinedEntity ets n)
 
 #guard_msgs(drop info, drop warning) in
-#derive_generator (fun (n : EntityName) => Cedar.DefinedEntity ets n)
+derive_generator (fun ets => ∃ (n : EntityName), Cedar.DefinedEntity ets n)
 
 #guard_msgs(drop info, drop warning) in
-#derive_checker (Cedar.DefinedEntities ets n)
+derive_checker (fun ets n => Cedar.DefinedEntities ets n)
 
 #guard_msgs(drop info, drop warning) in
-#derive_generator (fun (n : List EntityName) => Cedar.DefinedEntities ets n)
+derive_generator (fun ets => ∃ (n : List EntityName), Cedar.DefinedEntities ets n)
 
 ---------------------------------------------
 -- Schema: LookupEntityAttr / GetEntityAttr
 ---------------------------------------------
 
 #guard_msgs(drop info, drop warning) in
-#derive_checker (Cedar.LookupEntityAttr l fnb t)
+derive_checker (fun l fnb t => Cedar.LookupEntityAttr l fnb t)
 
 #guard_msgs(drop info, drop warning) in
-#derive_generator (fun (fnb : (String × Bool)) => Cedar.LookupEntityAttr l fnb t)
+derive_generator (fun l t => ∃ (fnb : (String × Bool)), Cedar.LookupEntityAttr l fnb t)
 
 #guard_msgs(drop info, drop warning) in
-#derive_generator (fun (nfn : (EntityName × String × Bool)) => Cedar.GetEntityAttr ets nfn t)
+derive_generator (fun ets t => ∃ (nfn : (EntityName × String × Bool)), Cedar.GetEntityAttr ets nfn t)
 
 #guard_msgs(drop info, drop warning) in
-#derive_checker (Cedar.ReqContextToCedarType c t)
+derive_checker (fun c t => Cedar.ReqContextToCedarType c t)
 
 #guard_msgs(drop info, drop warning) in
-#derive_generator (fun (t : CedarType) => Cedar.ReqContextToCedarType c t)
+derive_generator (fun c => ∃ (t : CedarType), Cedar.ReqContextToCedarType c t)
 
 #guard_msgs(drop info, drop warning) in
-#derive_generator (fun (reqs : List RequestType) => Cedar.ActionToRequestTypes e n ns l rs reqs)
+derive_generator (fun e n ns l rs => ∃ (reqs : List RequestType), Cedar.ActionToRequestTypes e n ns l rs reqs)
 
 #guard_msgs(drop info, drop warning) in
-#derive_generator (fun (reqs : List RequestType) => Cedar.ActionSchemaEntryToRequestTypes e ae ls reqs)
+derive_generator (fun e ae ls => ∃ (reqs : List RequestType), Cedar.ActionSchemaEntryToRequestTypes e ae ls reqs)
 
 #guard_msgs(drop info, drop warning) in
-#derive_generator (fun (reqs : List RequestType) => Cedar.ActionSchemaToRequestTypes acts ls reqs)
+derive_generator (fun acts ls => ∃ (reqs : List RequestType), Cedar.ActionSchemaToRequestTypes acts ls reqs)
 
 #guard_msgs(drop info, drop warning) in
-#derive_generator (fun (es : List Environment) => Cedar.SchemaToEnvironments s l es)
+derive_generator (fun s l => ∃ (es : List Environment), Cedar.SchemaToEnvironments s l es)
 
 ---------------------------------------
 -- Checker & Generator for RecordTypes
 ---------------------------------------
 
 #guard_msgs(drop info, drop warning) in
-#derive_checker (Cedar.RecordType ct)
+derive_checker (fun ct => Cedar.RecordType ct)
 
 #guard_msgs(drop info, drop warning) in
-#derive_generator (fun (ct : CedarType) => Cedar.RecordType ct)
+derive_generator ∃ (ct : CedarType), Cedar.RecordType ct
 
 --------------------
 -- Subtyping & Typing
 --------------------
 #guard_msgs(drop info, drop warning) in
-#derive_checker (Cedar.SubType t1 t2)
+derive_checker (fun t1 t2 => Cedar.SubType t1 t2)
 
 #guard_msgs(drop info, drop warning) in
-#derive_generator (fun (t1 : CedarType) => Cedar.SubType t1 t2)
+derive_generator (fun t2 => ∃ (t1 : CedarType), Cedar.SubType t1 t2)
 
 #guard_msgs(drop info, drop warning) in
-#derive_generator (fun (p : Prim) => Cedar.HasTypePrim v p t)
+derive_generator (fun v t => ∃ (p : Prim), Cedar.HasTypePrim v p t)
 
 #guard_msgs(drop info, drop warning) in
-#derive_generator (fun (t : CedarType) => Cedar.HasTypeVar v x t)
+derive_generator (fun v x => ∃ (t : CedarType), Cedar.HasTypeVar v x t)
 
 #guard_msgs(drop info, drop warning) in
-#derive_generator (fun (x : Var) => Cedar.HasTypeVar v x t)
+derive_generator (fun v t => ∃ (x : Var), Cedar.HasTypeVar v x t)
 
 #guard_msgs(drop info, drop warning) in
-#derive_checker (Cedar.BindAttrType ns tef t)
+derive_checker (fun ns tef t => Cedar.BindAttrType ns tef t)
 
 #guard_msgs(drop info, drop warning) in
-#derive_generator (fun (tef : (CedarType × String × Bool)) => Cedar.BindAttrType ns tef t)
+derive_generator (fun ns t => ∃ (tef : (CedarType × String × Bool)), Cedar.BindAttrType ns tef t)
 
 #guard_msgs(drop info) in
-#derive_generator (fun (T : _) => Cedar.BindAttrType ns (TE, F, true) T)
+derive_generator (fun ns p => ∃ (T : _), Cedar.BindAttrType ns p T)
 
 ------------------------------------------------------------
 -- Generator for well-typed Cedar expressions
 ------------------------------------------------------------
 
 #guard_msgs(drop info, drop warning) in
-#derive_generator (fun (ex : (CedarExpr × PathSet)) => Cedar.HasType a v ex t)
+derive_generator (fun a v t => ∃ (ex : (CedarExpr × PathSet)), Cedar.HasType a v ex t)

--- a/Test/DeriveArbitrarySuchThat/DeriveBSTGenerator.lean
+++ b/Test/DeriveArbitrarySuchThat/DeriveBSTGenerator.lean
@@ -13,12 +13,12 @@ open ArbitrarySizedSuchThat
 set_option guard_msgs.diff true
 
 #guard_msgs(drop info, drop warning) in
-#derive_generator (fun (x : Nat) => Between lo x hi)
+derive_generator (fun lo hi => ∃ (x : Nat), Between lo x hi)
 
 deriving instance Arbitrary for BinaryTree
 
 #guard_msgs(drop info, drop warning) in
-#derive_generator (fun (t : BinaryTree) => BST lo hi t)
+derive_generator (fun lo hi => ∃ (t : BinaryTree), BST lo hi t)
 
 
 /-- Inserts an element into a tree, respecting the BST invariants -/
@@ -61,4 +61,6 @@ def runTests (numTrials : Nat) (useBuggyVersion : Bool := false) : IO Unit := do
   IO.println s!"Chamelean: finished {numTrials} tests, {numSucceeded} passed"
 
 -- Uncomment this to run the aforementioned test harness
+-- Sadly this cannot be made a #guard_msg since the counter-example is non-deterministic
+
 -- #eval runTests (numTrials := 100) (useBuggyVersion := true)

--- a/Test/DeriveArbitrarySuchThat/DeriveBalancedTreeGenerator.lean
+++ b/Test/DeriveArbitrarySuchThat/DeriveBalancedTreeGenerator.lean
@@ -20,4 +20,4 @@ inductive balancedTree : Nat → BinaryTree → Prop where
     balancedTree (.succ n) (BinaryTree.Node x l r)
 
 #guard_msgs(drop info, drop warning) in
-#derive_generator (fun (t : BinaryTree) => balancedTree n t)
+derive_generator (fun n => ∃ (t : BinaryTree), balancedTree n t)

--- a/Test/DeriveArbitrarySuchThat/DerivePermutationGenerator.lean
+++ b/Test/DeriveArbitrarySuchThat/DerivePermutationGenerator.lean
@@ -3,7 +3,7 @@ import Plausible.Chamelean.ArbitrarySizedSuchThat
 import Test.CommonDefinitions.Permutation
 
 #guard_msgs(drop info, drop warning) in
-#derive_generator (fun (l : List Nat) => Permutation l l')
+derive_generator (fun l' => ∃ (l : List Nat), Permutation l l')
 
 #guard_msgs(drop info, drop warning) in
-#derive_generator (fun (l : List Nat) => Permutation l' l)
+derive_generator (fun l' => ∃ (l : List Nat), Permutation l' l)

--- a/Test/DeriveArbitrarySuchThat/DeriveRegExpMatchGenerator.lean
+++ b/Test/DeriveArbitrarySuchThat/DeriveRegExpMatchGenerator.lean
@@ -60,7 +60,7 @@ def r0 : RegExp :=
 -- Generator for strings that match the regexp `re`
 
 #guard_msgs(drop info, drop warning) in
-#derive_generator (fun (s : List Nat) => ExpMatch s re)
+derive_generator (fun re => ∃ (s : List Nat), ExpMatch s re)
 
 -- To sample from this generator and print out 10 successful examples using the `Repr`
 -- instance for `List Nat`, we can run the following:

--- a/Test/DeriveArbitrarySuchThat/DeriveSTLCGenerator.lean
+++ b/Test/DeriveArbitrarySuchThat/DeriveSTLCGenerator.lean
@@ -12,16 +12,16 @@ open ArbitrarySizedSuchThat
 set_option guard_msgs.diff true
 
 #guard_msgs(drop info, drop warning) in
-#derive_generator (fun (x : Nat) => lookup Γ x τ)
+derive_generator (fun Γ τ => ∃ (x : Nat), lookup Γ x τ)
 
 #guard_msgs(drop info, drop warning) in
-#derive_generator (fun (τ : type) => lookup Γ x τ)
+derive_generator (fun Γ x => ∃ (τ : type), lookup Γ x τ)
 
 #guard_msgs(drop info, drop warning) in
-#derive_generator (fun (t : type) => typing G e t)
+derive_generator (fun G e => ∃ (t : type), typing G e t)
 
 #guard_msgs(drop info, drop warning) in
-#derive_generator (fun (e : term) => typing G e t)
+derive_generator (fun G t => ∃ (e : term), typing G e t)
 
 -- To sample from this generator and print out 10 successful examples using the `Repr`
 -- instance for `term`, we can run the following:

--- a/Test/DeriveArbitrarySuchThat/FunctionCallsTest.lean
+++ b/Test/DeriveArbitrarySuchThat/FunctionCallsTest.lean
@@ -9,4 +9,4 @@ open DecOpt
 set_option guard_msgs.diff true
 
 #guard_msgs(drop info, drop warning) in
-#derive_generator (fun (n : Nat) => square_of n m)
+derive_generator (fun m => ∃ (n : Nat), square_of n m)

--- a/Test/DeriveArbitrarySuchThat/MutuallyRecursiveRelationsTest.lean
+++ b/Test/DeriveArbitrarySuchThat/MutuallyRecursiveRelationsTest.lean
@@ -19,7 +19,7 @@ end
     manually add a dummy instance of `ArbitrarySizedSuchThat` for one of the relations, since Lean doesn't support
     mutually recursively typeclass instances currently.
 
-    Note that the instance of `ArbitrarySizedSuchThat` for `Odd` below (produced by `#derive_generator`)
+    Note that the instance of `ArbitrarySizedSuchThat` for `Odd` below (produced by `derive_generator`)
     will shadow this one -- it takes precedence over this dummy instance.
 
 
@@ -28,7 +28,7 @@ instance : ArbitrarySizedSuchThat Nat (fun n => Odd n) where
   arbitrarySizedST (_ : Nat) := return 1
 
 #guard_msgs(drop info, drop warning) in
-#derive_generator (fun (n : Nat) => Even n)
+derive_generator ∃ (n : Nat), Even n
 
 #guard_msgs(drop info, drop warning) in
-#derive_generator (fun (n : Nat) => Odd n)
+derive_generator ∃ (n : Nat), Odd n

--- a/Test/DeriveArbitrarySuchThat/NonLinearPatternsTest.lean
+++ b/Test/DeriveArbitrarySuchThat/NonLinearPatternsTest.lean
@@ -15,7 +15,7 @@ inductive GoodTree : Nat → Nat → BinaryTree → Prop where
   | GoodLeaf : ∀ n, GoodTree n n .Leaf
 
 #guard_msgs(drop info, drop warning) in
-#derive_generator (fun (t : BinaryTree) => GoodTree in1 in2 t)
+derive_generator (fun in1 in2 => ∃ (t : BinaryTree), GoodTree in1 in2 t)
 
 
 /-- `SameHead xs ys` means the lists `xs` and `ys` have the same head
@@ -25,4 +25,4 @@ inductive SameHead : List Nat → List Nat → Prop where
 | HeadMatch : ∀ x xs ys, SameHead (x::xs) (x::ys)
 
 #guard_msgs(drop info, drop warning) in
-#derive_generator (fun (xs : List Nat) => SameHead xs ys)
+derive_generator (fun ys => ∃ (xs : List Nat), SameHead xs ys)

--- a/Test/DeriveArbitrarySuchThat/SimultaneousMatchingTests.lean
+++ b/Test/DeriveArbitrarySuchThat/SimultaneousMatchingTests.lean
@@ -13,20 +13,20 @@ set_option guard_msgs.diff true
 
 
 #guard_msgs(drop info, drop warning) in
-#derive_generator (fun (l : List Nat) => InList x l)
+derive_generator (fun x => ∃ (l : List Nat), InList x l)
 
 
 #guard_msgs(drop info, drop warning) in
-#derive_generator (fun (l: List Nat) => MinOk l a)
+derive_generator (fun a => ∃ (l: List Nat), MinOk l a)
 
 #guard_msgs(drop info, drop warning) in
-#derive_generator (fun (l : List Nat) => MinEx n l l')
+derive_generator (fun n l' => ∃ (l : List Nat), MinEx n l l')
 
 #guard_msgs(drop info, drop warning) in
-#derive_generator (fun (l : List Nat) => MinEx3 x l l')
+derive_generator (fun x l' => ∃ (l : List Nat), MinEx3 x l l')
 
 #guard_msgs(drop info, drop warning) in
-#derive_generator (fun (l' : List Nat) => MinEx2 x l l')
+derive_generator (fun x l => ∃ (l' : List Nat), MinEx2 x l l')
 
 #guard_msgs(drop info, drop warning) in
-#derive_generator (fun (l : List Nat) => MinEx2 x l l')
+derive_generator (fun x l' => ∃ (l : List Nat), MinEx2 x l l')

--- a/Test/DeriveArbitrarySuchThat/Syntax.lean
+++ b/Test/DeriveArbitrarySuchThat/Syntax.lean
@@ -1,0 +1,44 @@
+import Plausible.Chamelean.DeriveConstrainedProducer
+import Plausible.Attr
+
+set_option guard_msgs.diff true
+
+namespace Foo
+
+inductive Bar where
+| bar
+
+inductive Baz : Bar → Prop where
+| isBar : Baz .bar
+
+end Foo
+
+-- set_option trace.plausible.deriving.arbitrary true
+
+#guard_msgs(drop info) in
+derive_generator (∃ (b: Foo.Bar), Foo.Baz b)
+
+
+section
+
+open Foo
+
+#guard_msgs(drop info) in
+derive_generator (∃ (b: Bar), Baz b)
+
+
+inductive Baz' : Bar → Bar → Prop where
+| isBar2 : Baz' .bar .bar
+
+/-- error: Redundant alternative: Any expression matching
+  _
+will match one of the preceding alternatives
+---
+error: Redundant alternative: Any expression matching
+  _
+will match one of the preceding alternatives
+-/
+#guard_msgs(error, drop info) in
+derive_generator (fun a => ∃ b, Baz' a b)
+
+end

--- a/Test/DeriveArbitrarySuchThat/WithUnfolds.lean
+++ b/Test/DeriveArbitrarySuchThat/WithUnfolds.lean
@@ -46,10 +46,10 @@ error: failed to synthesize
 Hint: Additional diagnostic information may be available using the `set_option diagnostics true` command.
 -/
 #guard_msgs(error, drop info, drop warning) in
-#derive_generator (fun (n : Nat) => TypeBoxPred n)
+derive_generator ∃ (n : Nat), TypeBoxPred n
 
 #guard_msgs(error, drop info, drop warning) in
-#derive_generator (fun (n : _) => TypeBoxPredS n)
+derive_generator ∃ (n : _), TypeBoxPredS n
 
 #guard_msgs(drop error, drop warning, drop info) in
-#derive_generator (fun (n : Nat) => TypeBoxPred' n)
+derive_generator ∃ (n : Nat), TypeBoxPred' n

--- a/Test/DeriveDecOpt/DeriveBSTChecker.lean
+++ b/Test/DeriveDecOpt/DeriveBSTChecker.lean
@@ -8,7 +8,7 @@ open DecOpt
 set_option guard_msgs.diff true
 
 #guard_msgs(drop info, drop warning) in
-#derive_checker (Between lo x hi)
+derive_checker (fun lo x hi => Between lo x hi)
 
 #guard_msgs(drop info, drop warning) in
-#derive_checker (BST lo hi t)
+derive_checker (fun lo hi t => BST lo hi t)

--- a/Test/DeriveDecOpt/DeriveBalancedTreeChecker.lean
+++ b/Test/DeriveDecOpt/DeriveBalancedTreeChecker.lean
@@ -8,4 +8,4 @@ open DecOpt
 set_option guard_msgs.diff true
 
 #guard_msgs(drop info, drop warning) in
-#derive_checker (balancedTree n t)
+derive_checker (fun n t => balancedTree n t)

--- a/Test/DeriveDecOpt/DerivePermutationChecker.lean
+++ b/Test/DeriveDecOpt/DerivePermutationChecker.lean
@@ -5,7 +5,7 @@ import Test.DeriveEnumSuchThat.DerivePermutationEnumerator
 
 
 #guard_msgs(drop info, drop warning) in
-#derive_checker (Permutation l l')
+derive_checker (fun l l' => Permutation l l')
 
 
 -- Example: to run the derived checker, you can uncomment the following

--- a/Test/DeriveDecOpt/DeriveRegExpMatchChecker.lean
+++ b/Test/DeriveDecOpt/DeriveRegExpMatchChecker.lean
@@ -63,4 +63,4 @@ info: Try this checker: instance : DecOpt (ExpMatch s r0) where
     fun size => aux_dec size size s r0
 -/
 -- #guard_msgs(drop info, drop warning) in
--- #derive_checker (ExpMatch s r0)
+-- derive_checker (fun s r0 => ExpMatch s r0)

--- a/Test/DeriveDecOpt/DeriveSTLCChecker.lean
+++ b/Test/DeriveDecOpt/DeriveSTLCChecker.lean
@@ -10,4 +10,4 @@ open DecOpt
 set_option guard_msgs.diff true
 
 #guard_msgs(drop info, drop warning) in
-#derive_checker (typing Γ e τ)
+derive_checker (fun Γ e τ => typing Γ e τ)

--- a/Test/DeriveDecOpt/ExistentialVariablesTest.lean
+++ b/Test/DeriveDecOpt/ExistentialVariablesTest.lean
@@ -30,13 +30,13 @@ inductive NatChain (a b : Nat) : Prop where
     NatChain a b
 
 #guard_msgs(drop info, drop warning) in
-#derive_enumerator (fun (a : Nat) => LessThanEq a x)
+derive_enumerator (fun x => ∃ (a : Nat), LessThanEq a x)
 
 #guard_msgs(drop info, drop warning) in
-#derive_enumerator (fun (y : Nat) => LessThanEq x y)
+derive_enumerator (fun x => ∃ (y : Nat), LessThanEq x y)
 
 #guard_msgs(drop info, drop warning) in
-#derive_checker (LessThanEq n m)
+derive_checker (fun n m => LessThanEq n m)
 
 #guard_msgs(drop info, drop warning) in
-#derive_checker (NatChain a b)
+derive_checker (fun a b => NatChain a b)

--- a/Test/DeriveDecOpt/FunctionCallsTest.lean
+++ b/Test/DeriveDecOpt/FunctionCallsTest.lean
@@ -9,4 +9,4 @@ open DecOpt
 set_option guard_msgs.diff true
 
 #guard_msgs(drop info, drop warning) in
-#derive_checker (square_of n m)
+derive_checker (fun n m => square_of n m)

--- a/Test/DeriveDecOpt/NonLinearPatternsTest.lean
+++ b/Test/DeriveDecOpt/NonLinearPatternsTest.lean
@@ -8,4 +8,4 @@ open DecOpt
 set_option guard_msgs.diff true
 
 #guard_msgs(drop info, drop warning) in
-#derive_checker (GoodTree in1 in2 t)
+derive_checker (fun in1 in2 t => GoodTree in1 in2 t)

--- a/Test/DeriveDecOpt/SimultaneousMatchingTests.lean
+++ b/Test/DeriveDecOpt/SimultaneousMatchingTests.lean
@@ -8,10 +8,10 @@ open DecOpt
 set_option guard_msgs.diff true
 
 #guard_msgs(drop info, drop warning) in
-#derive_checker (InList x l)
+derive_checker (fun x l => InList x l)
 
 #guard_msgs(drop info, drop warning) in
-#derive_checker (MinOk l a)
+derive_checker (fun l a => MinOk l a)
 
 #guard_msgs(drop info, drop warning) in
-#derive_checker (MinEx n l a)
+derive_checker (fun n l a => MinEx n l a)

--- a/Test/DeriveEnum/BitVecStructureTest.lean
+++ b/Test/DeriveEnum/BitVecStructureTest.lean
@@ -20,6 +20,6 @@ deriving instance Enum for DummyInductive
 namespace CommandElaboratorTest
 
 #guard_msgs(drop info, drop warning) in
-#derive_enum DummyInductive
+derive_enum DummyInductive
 
 end CommandElaboratorTest

--- a/Test/DeriveEnum/DeriveNKIBinopEnumerator.lean
+++ b/Test/DeriveEnum/DeriveNKIBinopEnumerator.lean
@@ -20,6 +20,6 @@ deriving instance Enum for BinOp
 namespace CommandElaboratorTest
 
 #guard_msgs(drop info, drop warning) in
-#derive_enum BinOp
+derive_enum BinOp
 
 end CommandElaboratorTest

--- a/Test/DeriveEnum/DeriveNKIValueEnumerator.lean
+++ b/Test/DeriveEnum/DeriveNKIValueEnumerator.lean
@@ -20,6 +20,6 @@ set_option guard_msgs.diff true
 namespace CommandElaboratorTest
 
 #guard_msgs(drop info, drop warning) in
-#derive_enum Value
+derive_enum Value
 
 end CommandElaboratorTest

--- a/Test/DeriveEnum/DeriveRegExpEnumerator.lean
+++ b/Test/DeriveEnum/DeriveRegExpEnumerator.lean
@@ -20,6 +20,6 @@ deriving instance Enum for RegExp
 namespace CommandElaboratorTest
 
 #guard_msgs(drop info, drop warning) in
-#derive_enum RegExp
+derive_enum RegExp
 
 end CommandElaboratorTest

--- a/Test/DeriveEnum/DeriveSTLCTermTypeEnumerators.lean
+++ b/Test/DeriveEnum/DeriveSTLCTermTypeEnumerators.lean
@@ -28,9 +28,9 @@ deriving instance Enum for type, term
 namespace CommandElaboratorTest
 
 #guard_msgs(drop info, drop warning) in
-#derive_enum type
+derive_enum type
 
 #guard_msgs(drop info, drop warning) in
-#derive_enum term
+derive_enum term
 
 end CommandElaboratorTest

--- a/Test/DeriveEnum/DeriveTreeEnumerator.lean
+++ b/Test/DeriveEnum/DeriveTreeEnumerator.lean
@@ -21,6 +21,6 @@ deriving instance Enum for BinaryTree
 namespace CommandElaboratorTest
 
 #guard_msgs(drop info, drop warning) in
-#derive_enum BinaryTree
+derive_enum BinaryTree
 
 end CommandElaboratorTest

--- a/Test/DeriveEnum/StructureTest.lean
+++ b/Test/DeriveEnum/StructureTest.lean
@@ -20,6 +20,6 @@ deriving instance Enum for Foo
 namespace CommandElaboratorTest
 
 #guard_msgs(drop info, drop warning) in
-#derive_enum Foo
+derive_enum Foo
 
 end CommandElaboratorTest

--- a/Test/DeriveEnumSuchThat/DeriveBSTEnumerator.lean
+++ b/Test/DeriveEnumSuchThat/DeriveBSTEnumerator.lean
@@ -7,7 +7,7 @@ import Test.DeriveArbitrarySuchThat.DeriveBSTGenerator
 set_option guard_msgs.diff true
 
 #guard_msgs(drop info, drop warning) in
-#derive_enumerator (fun (x : Nat) => Between lo x hi)
+derive_enumerator (fun lo hi => ∃ (x : Nat), Between lo x hi)
 
 #guard_msgs(drop info, drop warning) in
-#derive_enumerator (fun (t : BinaryTree) => BST lo hi t)
+derive_enumerator (fun lo hi => ∃ (t : BinaryTree), BST lo hi t)

--- a/Test/DeriveEnumSuchThat/DeriveBalancedTreeEnumerator.lean
+++ b/Test/DeriveEnumSuchThat/DeriveBalancedTreeEnumerator.lean
@@ -7,4 +7,4 @@ import Test.DeriveArbitrarySuchThat.DeriveBalancedTreeGenerator
 set_option guard_msgs.diff true
 
 #guard_msgs(drop info, drop warning) in
-#derive_enumerator (fun (t : BinaryTree) => balancedTree n t)
+derive_enumerator (fun n => ∃ (t : BinaryTree), balancedTree n t)

--- a/Test/DeriveEnumSuchThat/DerivePermutationEnumerator.lean
+++ b/Test/DeriveEnumSuchThat/DerivePermutationEnumerator.lean
@@ -4,7 +4,7 @@ import Test.CommonDefinitions.Permutation
 
 
 #guard_msgs(drop info, drop warning) in
-#derive_enumerator (fun (l : List Nat) => Permutation l l')
+derive_enumerator (fun l' => ∃ (l : List Nat), Permutation l l')
 
 #guard_msgs(drop info, drop warning) in
-#derive_enumerator (fun (l : List Nat) => Permutation l' l)
+derive_enumerator (fun l' => ∃ (l : List Nat), Permutation l' l)

--- a/Test/DeriveEnumSuchThat/DeriveRegExpMatchEnumerator.lean
+++ b/Test/DeriveEnumSuchThat/DeriveRegExpMatchEnumerator.lean
@@ -7,7 +7,7 @@ import Test.DeriveArbitrarySuchThat.DeriveRegExpMatchGenerator
 set_option guard_msgs.diff true
 
 #guard_msgs(drop info, drop warning) in
-#derive_enumerator (fun (s : List Nat) => ExpMatch s r0)
+derive_enumerator (fun r0 => ∃ (s : List Nat), ExpMatch s r0)
 
 -- To sample from this enumerator, we can run the following:
 #guard_msgs(drop info) in

--- a/Test/DeriveEnumSuchThat/DeriveSTLCEnumerator.lean
+++ b/Test/DeriveEnumSuchThat/DeriveSTLCEnumerator.lean
@@ -9,13 +9,13 @@ import Test.DeriveEnum.DeriveSTLCTermTypeEnumerators
 set_option guard_msgs.diff true
 
 #guard_msgs(drop info, drop warning) in
-#derive_enumerator (fun (x : Nat) => lookup Γ x τ)
+derive_enumerator (fun Γ τ => ∃ (x : Nat), lookup Γ x τ)
 
 #guard_msgs(drop info, drop warning) in
-#derive_checker (lookup Γ x τ)
+derive_checker (fun Γ x τ => lookup Γ x τ)
 
 #guard_msgs(drop info, drop warning) in
-#derive_enumerator (fun (τ : type) => lookup Γ x τ)
+derive_enumerator (fun Γ x => ∃ (τ : type), lookup Γ x τ)
 
 
 mutual
@@ -129,10 +129,10 @@ instance : DecOpt (typing Γ_1 e_1 τ_1) where
   decOpt := checkTyping Γ_1 e_1 τ_1
 
 #guard_msgs(drop info, drop warning) in
-#derive_enumerator (fun (τ : type) => lookup Γ x τ)
+derive_enumerator (fun Γ x => ∃ (τ : type), lookup Γ x τ)
 
 #guard_msgs(drop info, drop warning) in
-#derive_enumerator (fun (τ : type) => typing Γ e τ)
+derive_enumerator (fun Γ e => ∃ (τ : type), typing Γ e τ)
 
 #guard_msgs(drop info, drop warning) in
-#derive_enumerator (fun (e : term) => typing Γ e τ)
+derive_enumerator (fun Γ τ => ∃ (e : term), typing Γ e τ)

--- a/Test/DeriveEnumSuchThat/NonLinearPatternsTest.lean
+++ b/Test/DeriveEnumSuchThat/NonLinearPatternsTest.lean
@@ -10,4 +10,4 @@ import Test.DeriveArbitrarySuchThat.NonLinearPatternsTest
 set_option guard_msgs.diff true
 
 #guard_msgs(drop info, drop warning) in
-#derive_enumerator (fun (t : BinaryTree) => GoodTree in1 in2 t)
+derive_enumerator (fun in1 in2 => ∃ (t : BinaryTree), GoodTree in1 in2 t)

--- a/Test/DeriveEnumSuchThat/SimultaneousMatchingTests.lean
+++ b/Test/DeriveEnumSuchThat/SimultaneousMatchingTests.lean
@@ -10,10 +10,10 @@ import Test.CommonDefinitions.ListRelations
 set_option guard_msgs.diff true
 
 #guard_msgs(drop info, drop warning) in
-#derive_enumerator (fun (l : List Nat) => InList x l)
+derive_enumerator (fun x => ∃ (l : List Nat), InList x l)
 
 #guard_msgs(drop info, drop warning) in
-#derive_enumerator (fun (l: List Nat) => MinOk l a)
+derive_enumerator (fun a => ∃ (l: List Nat), MinOk l a)
 
 #guard_msgs(drop info, drop warning) in
-#derive_enumerator (fun (l: List Nat) => MinEx n l a)
+derive_enumerator (fun n a => ∃ (l: List Nat), MinEx n l a)

--- a/Test/Enum/EnumeratorSizeTest.lean
+++ b/Test/Enum/EnumeratorSizeTest.lean
@@ -21,9 +21,9 @@ combining them into the top level enumerator for an inductive family.
 -/
 
 #guard_msgs(drop info, drop warning) in
-#derive_enumerator (fun (n : _) => onetrue n)
+derive_enumerator ∃ (n : _), onetrue n
 #guard_msgs(drop info, drop warning) in
-#derive_enumerator (fun (n : _) => onetrue' n)
+derive_enumerator ∃ (n : _), onetrue' n
 
 /--
 info: 1

--- a/Test/KeyValueStoreExample/TestKeyValueStoreCheckerGenerators.lean
+++ b/Test/KeyValueStoreExample/TestKeyValueStoreCheckerGenerators.lean
@@ -26,49 +26,49 @@ instance instKeyValueStoreArbitraryString : Arbitrary String where
 ---------------------------------------------------------------------------------------------------------------------------------------
 
 #guard_msgs(drop info, drop warning) in
-#derive_generator (fun (s1 : List (String × String)) => KeyValueStore.RemoveKV k s1 s2)
+derive_generator (fun k s2 => ∃ (s1 : List (String × String)), KeyValueStore.RemoveKV k s1 s2)
 
 #guard_msgs(drop info, drop warning) in
-#derive_generator (fun (s2 : List (String × String)) => KeyValueStore.RemoveKV k s1 s2)
+derive_generator (fun k s1 => ∃ (s2 : List (String × String)), KeyValueStore.RemoveKV k s1 s2)
 
 #guard_msgs(drop info, drop warning) in
-#derive_generator (fun (s1 : List (String × String)) => KeyValueStore.AddKV k v s1 s2)
+derive_generator (fun k v s2 => ∃ (s1 : List (String × String)), KeyValueStore.AddKV k v s1 s2)
 
 #guard_msgs(drop info, drop warning) in
-#derive_generator (fun (s2 : List (String × String)) => KeyValueStore.AddKV k v s1 s2)
+derive_generator (fun k v s1 => ∃ (s2 : List (String × String)), KeyValueStore.AddKV k v s1 s2)
 
 #guard_msgs(drop info, drop warning) in
-#derive_generator (fun (v : String) => KeyValueStore.AddKV k v x_1 s2)
+derive_generator (fun k x_1 s2 => ∃ (v : String), KeyValueStore.AddKV k v x_1 s2)
 
 #guard_msgs(drop info, drop warning) in
-#derive_checker (KeyValueStore.LookupKV s kv)
+derive_checker (fun s kv => KeyValueStore.LookupKV s kv)
 
 #guard_msgs(drop info, drop warning) in
-#derive_generator (fun (s1 : List (String × String)) => KeyValueStore.LookupKV s1 kv)
+derive_generator (fun kv => ∃ (s1 : List (String × String)), KeyValueStore.LookupKV s1 kv)
 
 #guard_msgs(drop info, drop warning) in
-#derive_checker (KeyValueStore.AddKV k2 v s_1 s2)
+derive_checker (fun k2 v s_1 s2 => KeyValueStore.AddKV k2 v s_1 s2)
 
 -- #guard_msgs(drop info, drop warning) in
--- #derive_generator (fun (s : List (String × String)) => KeyValueStore.EvalStateApiCall s x)
+-- derive_generator (fun x => ∃ (s : List (String × String)), KeyValueStore.EvalStateApiCall s x)
 
 #guard_msgs(drop info, drop warning) in
-#derive_generator (fun (kv : StateResult × String × Nat × String) => KeyValueStore.LookupKV s kv)
+derive_generator (fun s => ∃ (kv : StateResult × String × Nat × String), KeyValueStore.LookupKV s kv)
 
 #guard_msgs(drop info, drop warning) in
-#derive_generator (fun (nb : Nat × List (String × String)) => KeyValueStore.GetBucket s nb)
+derive_generator (fun s => ∃ (nb : Nat × List (String × String)), KeyValueStore.GetBucket s nb)
 
 #guard_msgs(drop info, drop warning) in
-#derive_generator (fun (k : _) => KeyValueStore.AddKV k v x_1 s2)
+derive_generator (fun v x_1 s2 => ∃ (k : _), KeyValueStore.AddKV k v x_1 s2)
 
 #guard_msgs(drop info, drop warning) in
-#derive_generator (fun (foo : StateAPICall × StateResult × List (String × String)) => KeyValueStore.EvalStateApiCall x foo)
+derive_generator (fun x => ∃ (foo : StateAPICall × StateResult × List (String × String)), KeyValueStore.EvalStateApiCall x foo)
 
 #guard_msgs(drop info, drop warning) in
-#derive_generator (fun (crns : APICall × Result × (Nat × List (Nat × List (String × String)))) => KeyValueStore.EvalApiCall s crns)
+derive_generator (fun s => ∃ (crns : APICall × Result × (Nat × List (Nat × List (String × String)))), KeyValueStore.EvalApiCall s crns)
 
 #guard_msgs(drop info, drop warning) in
-#derive_generator (fun (o : List (APICall × Result) × (Nat × List (Nat × List (String × String)))) => KeyValueStore.EvalApiCalls s o)
+derive_generator (fun s => ∃ (o : List (APICall × Result) × (Nat × List (Nat × List (String × String)))), KeyValueStore.EvalApiCalls s o)
 
 
 /- Uncommenting the following line results in random sequences of API Calls, such as:


### PR DESCRIPTION
And make it more flexible: we take in a term of the form `(fun x y z .. => exists w, P x y w)` and run the elaborator to get somewhat more robust parsing. We now error if an argument to P is not a variable, which we probably wanted to do anyway.