### PR TITLE
feat: Type arguments supported in generator/checker derivation

### DIFF
--- a/Plausible/Chamelean/DeriveChecker.lean
+++ b/Plausible/Chamelean/DeriveChecker.lean
@@ -1,7 +1,6 @@
 import Lean
 
 import Plausible.Chamelean.MakeConstrainedProducerInstance
-import Plausible.Chamelean.Enumerators
 import Plausible.Chamelean.DeriveConstrainedProducer
 import Plausible.Chamelean.Idents
 import Plausible.Chamelean.DecOpt

--- a/Plausible/Chamelean/DeriveChecker.lean
+++ b/Plausible/Chamelean/DeriveChecker.lean
@@ -1,6 +1,7 @@
 import Lean
 
 import Plausible.Chamelean.MakeConstrainedProducerInstance
+import Plausible.Chamelean.Enumerators
 import Plausible.Chamelean.DeriveConstrainedProducer
 import Plausible.Chamelean.Idents
 import Plausible.Chamelean.DecOpt
@@ -37,7 +38,7 @@ def getCheckerScheduleForInductiveConstructor (inductiveName : Name) (ctorName :
     - Note: this function is identical to `mkTopLevelChecker`, except it doesn't take in a `NameMap` argument
     - TODO: refactor to avoid code duplication -/
 def mkDecOptInstance (baseCheckers : TSyntax `term) (inductiveCheckers : TSyntax `term)
-  (inductiveName : Name) (args : TSyntaxArray `term) (topLevelLocalCtx : LocalContext) : TermElabM (TSyntax `command) := do
+  (inductiveName : Name) (inductiveLevels : List Level) (args : TSyntaxArray `term) (topLevelLocalCtx : LocalContext) : TermElabM (TSyntax `command) := do
 
   -- Produce a fresh name for the `size` argument for the lambda
   -- at the end of the checker function, as well as the `aux_dec` inner helper function
@@ -61,7 +62,7 @@ def mkDecOptInstance (baseCheckers : TSyntax `term) (inductiveCheckers : TSyntax
   let matchExpr ← mkMatchExpr sizeIdent caseExprs
 
   -- Add parameters for each argument to the inductive relation
-  let paramInfo ← analyzeInductiveArgs inductiveName args
+  let paramInfo ← analyzeInductiveArgs inductiveName inductiveLevels args
 
   -- Inner params are for the inner `aux_dec` function
   let mut innerParams := #[]
@@ -70,24 +71,34 @@ def mkDecOptInstance (baseCheckers : TSyntax `term) (inductiveCheckers : TSyntax
 
   -- Outer params are for the top-level lambda function which invokes `aux_dec`
   let mut outerParams := #[]
-  for (paramName, paramType) in paramInfo do
+  let mut typeParams := #[]
+  for (paramName, paramType, paramTypeSyntax) in paramInfo do
     let outerParamIdent := mkIdent paramName
     outerParams := outerParams.push outerParamIdent
 
+    if paramType.isSort then typeParams := typeParams.push paramName
+
     -- Inner parameters are for the inner `aux_arb` function
-    let innerParam ← `(Term.letIdBinder| ($(mkIdent paramName) : $paramType))
+    let innerParam ←
+    if paramType.isSort then
+     `(Term.letIdBinder| ($(mkIdent paramName) : _))
+    else
+     `(Term.letIdBinder| ($(mkIdent paramName) : $paramTypeSyntax))
     innerParams := innerParams.push innerParam
 
+  let arbitraryTypeParamInstances ← mkTypeClassInstanceBinders typeParams #[``Enum, ``DecidableEq]
+
   -- Produces an instance of the `DecOpt` typeclass containing the definition for the derived generator
-  `(instance : $decOptTypeclass ($(mkIdent inductiveName) $args*) where
+  `(instance $arbitraryTypeParamInstances:bracketedBinder* : $decOptTypeclass (@$(mkIdent inductiveName) $args*) where
       $unqualifiedDecOptFn:ident :=
-        let rec $auxDecIdent:ident $innerParams* : $checkerType :=
+        let rec $auxDecIdent:ident $innerParams* $arbitraryTypeParamInstances:bracketedBinder* : $checkerType :=
           $matchExpr
         fun $freshSizeIdent => $auxDecIdent $freshSizeIdent $freshSizeIdent $outerParams*)
 
 
 def deriveScheduledChecker' (_args : Array Expr)
     (constrInd : Name)
+    (constrLevels : List Level)
     (constrArgs : Array Expr) : TermElabM (TSyntax `command) := do
   -- Parse `inductiveProp` for an application of the inductive relation
 
@@ -179,13 +190,14 @@ def deriveScheduledChecker' (_args : Array Expr)
     baseCheckers
     inductiveCheckers
     constrInd
+    constrLevels
     freshArgIdents
     localCtx
 
 private def withParsedDerivingArgs (input : Expr)
   (action :
     (args : Array Expr) →
-    (constrInd : Name) → (constrArgs : Array Expr) → TermElabM α) : TermElabM α :=
+    (constrInd : Name) → (constrLevels : List Level) → (constrArgs : Array Expr) → TermElabM α) : TermElabM α :=
   lambdaTelescope input <|
   fun args body => do
   let body ← whnf body
@@ -193,7 +205,8 @@ private def withParsedDerivingArgs (input : Expr)
   fun ind indArgs => do
   if !ind.isConst then throwError m!"Error in parsing constraint: {ind} is expected to be a constant."
   let indName := ind.constName!
-  action args indName indArgs
+  let indLevels := ind.constLevels!
+  action args indName indLevels indArgs
 
 /-- Derives a checker which checks the `inductiveProp` (an inductive relation, represented as a `TSyntax term`)
     using the unification algorithm from Generating Good Generators and the schedules discuseed in Testing Theorems -/

--- a/Plausible/Chamelean/MakeConstrainedProducerInstance.lean
+++ b/Plausible/Chamelean/MakeConstrainedProducerInstance.lean
@@ -21,9 +21,10 @@ def parseInductiveApp (body : Term) :
     return (indRel, #[])
   | _ => throwErrorAt body "Expected inductive type application"
 
+/-- Instantiates a known-to-be well-typed call to inductive with array of arguments `es` one
+    at a time and infers each arguments type, so renamings and dependent types are supported.
+    Returns the array of types for each argument in `es`. -/
 def getCorrectTypes (es : Array Expr) (ind : Name) (inductiveLevels : List Level) : TermElabM (Array Expr) := do
-  let _inductInfo ← getConstInfoInduct ind
-  -- TODO: deal with these mvars
   trace[plausible.deriving.arbitrary] m!"Levels for inductive {ind}: {inductiveLevels}"
   let mut t : Expr := .const ind inductiveLevels
   let mut tys : Array Expr := #[]
@@ -160,10 +161,8 @@ def mkConstrainedProducerTypeClassInstance
       | .Generator => mkFreshAccessibleIdent topLevelLocalCtx `aux_arb
       | .Enumerator => mkFreshAccessibleIdent topLevelLocalCtx `aux_enum
 
-    -- Build the syntax for the target type
-    -- Sadly, the delaborator may very well fail to produce a
-    -- syntactically correct term.
-    -- let targetTypeSyntax ← PrettyPrinter.delab targetType
+    -- Get the syntax for the target type, it must exist!
+    assert! outputType != none
     let targetTypeSyntax := outputType.get!
 
     -- Determine the appropriate type of the final producer

--- a/Plausible/Chamelean/MakeConstrainedProducerInstance.lean
+++ b/Plausible/Chamelean/MakeConstrainedProducerInstance.lean
@@ -1,6 +1,7 @@
 import Lean
 import Std
 import Plausible.Gen
+import Plausible.Chamelean.Enumerators
 import Plausible.Chamelean.GeneratorCombinators
 import Plausible.Chamelean.TSyntaxCombinators
 import Plausible.Chamelean.Idents
@@ -172,7 +173,12 @@ def mkConstrainedProducerTypeClassInstance
       | .Generator => `($genTypeConstructor $targetTypeSyntax)
       | .Enumerator => `($exceptTTypeConstructor $genErrorType $enumTypeConstructor $targetTypeSyntax)
 
-    let arbitraryTypeParamInstances ← mkTypeClassInstanceBinders typeParams #[``Plausible.Arbitrary, ``DecidableEq]
+    let producerUnconstrainedClass :=
+      match producerSort with
+      | .Generator => ``Plausible.Arbitrary
+      | .Enumerator => ``Enum
+
+    let arbitraryTypeParamInstances ← mkTypeClassInstanceBinders typeParams #[producerUnconstrainedClass, ``DecidableEq]
 
     -- Produce an instance of the appropriate typeclass containing the definition for the derived producer
     `(instance $arbitraryTypeParamInstances:bracketedBinder* : $producerTypeClass $targetTypeSyntax (fun $(mkIdent targetVar) => @$(mkIdent inductiveName) $args*) where

--- a/Plausible/Chamelean/MakeConstrainedProducerInstance.lean
+++ b/Plausible/Chamelean/MakeConstrainedProducerInstance.lean
@@ -79,7 +79,7 @@ def mkConstrainedProducerTypeClassInstance
   (inductiveName : Name)
   (inductiveLevels : List Level)
   (args : TSyntaxArray `term) (targetVar : Name)
-  (targetType : Expr)
+  (_targetType : Expr)
   (producerSort : ProducerSort)
   (topLevelLocalCtx : LocalContext) : TermElabM (TSyntax `command) := do
     -- Produce a fresh name for the `size` argument for the lambda

--- a/Plausible/Chamelean/MakeConstrainedProducerInstance.lean
+++ b/Plausible/Chamelean/MakeConstrainedProducerInstance.lean
@@ -21,44 +21,35 @@ def parseInductiveApp (body : Term) :
     return (indRel, #[])
   | _ => throwErrorAt body "Expected inductive type application"
 
+def getCorrectTypes (es : Array Expr) (ind : Name) (inductiveLevels : List Level) : TermElabM (Array Expr) := do
+  let _inductInfo ← getConstInfoInduct ind
+  -- TODO: deal with these mvars
+  trace[plausible.deriving.arbitrary] m!"Levels for inductive {ind}: {inductiveLevels}"
+  let mut t : Expr := .const ind inductiveLevels
+  let mut tys : Array Expr := #[]
+  for e in es do
+    tys := tys.push (← inferType t).bindingDomain!
+    t := .app t e
+  let resolvedExpr ← instantiateMVars t
+  trace[plausible.deriving.arbitrary] m!"Resolved mvar type: {t} {resolvedExpr}"
+  return tys
+
 /-- Analyzes the type of the inductive relation and matches each
     argument with its expected type, returning an array of
     (parameter name, type expression) pairs -/
-def analyzeInductiveArgs (inductiveName : Name) (args : Array Term) :
-  TermElabM (Array (Name × TSyntax `term)) := do
+def analyzeInductiveArgs (inductiveName : Name) (inductiveLevels : List Level) (args : Array Term) :
+  TermElabM (Array (Name × Expr × TSyntax `term)) := do
+  let argNames ← monadLift <| args.mapM extractParamName
+  let types ← getCorrectTypes (argNames.map (mkFVar ⟨·⟩)) inductiveName inductiveLevels
+  let typesSyntax ← monadLift <| types.mapM PrettyPrinter.delab
+  trace[plausible.deriving.arbitrary] m!"Types for inductive args: {typesSyntax}"
+  return argNames.zip (types.zip typesSyntax)
 
-  -- Extract the no. of parameters & indices for the inductive
-  let inductInfo ← getConstInfoInduct inductiveName
-  let numParams := inductInfo.numParams
-  let numIndices := inductInfo.numIndices
-  let numArgs := numParams + numIndices
-
-  if args.size != numArgs then
-    throwError s!"Expected {numArgs} arguments but received {args.size} arguments instead"
-
-  -- Extract the type of the inductive relation
-  let inductType := inductInfo.type
-
-
-  forallTelescope inductType (fun xs _ => do
-    let mut paramInfo : Array (Name × TSyntax `term) := #[]
-
-    for i in [:args.size] do
-        -- Match each argument with its expected type
-        let arg := args[i]!
-        let paramFVar := xs[i]!
-        let paramType ← inferType paramFVar
-
-        -- Extract parameter name from the argument syntax
-        let paramName ← extractParamName arg
-
-        -- Use Lean's delaborator to express the parameter type
-        -- using concrete surface-level syntax
-        let typeSyntax ← PrettyPrinter.delab paramType
-
-        paramInfo := paramInfo.push (paramName, typeSyntax)
-
-      pure paramInfo)
+def mkTypeClassInstanceBinders (typeParams : Array Name) (typeClasses : Array Name) : TermElabM (TSyntaxArray `Lean.Parser.Term.bracketedBinder) := do
+  let instances ← typeParams.flatMapM fun param =>
+    typeClasses.mapM fun tc =>
+      `(Lean.Elab.Deriving.instBinderF| [$(mkIdent tc) $(mkIdent param)])
+  return TSyntaxArray.mk instances
 
 /-- Finds the index of the argument in the inductive application for the value we wish to generate
     (i.e. finds `i` s.t. `args[i] == targetVar`) -/
@@ -86,6 +77,7 @@ def mkConstrainedProducerTypeClassInstance
   (baseGenerators : TSyntax `term)
   (inductiveGenerators : TSyntax `term)
   (inductiveName : Name)
+  (inductiveLevels : List Level)
   (args : TSyntaxArray `term) (targetVar : Name)
   (targetType : Expr)
   (producerSort : ProducerSort)
@@ -118,7 +110,7 @@ def mkConstrainedProducerTypeClassInstance
 
     -- Add parameters for each argument to the inductive relation
     -- (except the target variable, which we'll filter out later)
-    let paramInfo ← analyzeInductiveArgs inductiveName args
+    let paramInfo ← analyzeInductiveArgs inductiveName inductiveLevels args
 
     -- Inner params are for the inner `aux_arb` / `aux_enum` function
     let mut innerParams := #[]
@@ -127,17 +119,27 @@ def mkConstrainedProducerTypeClassInstance
 
     -- Outer params are for the top-level lambda function which invokes `aux_arb` / `aux_enum`
     let mut outerParams := #[]
-    for (paramName, paramType) in paramInfo do
+    let mut outputType := none
+    let mut typeParams := #[]
+    for (paramName, paramType, paramTypeSyntax) in paramInfo do
       -- Only add a function parameter is the argument to the inductive relation is not the target variable
       -- (We skip the target variable since that's the value we wish to generate)
+      if paramType.isSort then
+        typeParams := typeParams.push paramName
       if paramName != targetVar then
         let outerParamIdent := mkIdent paramName
         outerParams := outerParams.push outerParamIdent
 
         let innerParamIdent := mkIdent paramName
 
-        let innerParam ← `(Term.letIdBinder| ($innerParamIdent : $paramType))
+        let innerParam ← if paramType.isSort then
+          `(Term.letIdBinder| ($innerParamIdent : Sort _))
+          else
+          `(Term.letIdBinder| ($innerParamIdent : $paramTypeSyntax))
+
         innerParams := innerParams.push innerParam
+      else
+        outputType := some paramTypeSyntax
 
     -- Figure out which typeclass should be derived
     -- (`ArbitrarySizedSuchThat` for generators, `EnumSizedSuchThat` for enumerators)
@@ -161,7 +163,8 @@ def mkConstrainedProducerTypeClassInstance
     -- Build the syntax for the target type
     -- Sadly, the delaborator may very well fail to produce a
     -- syntactically correct term.
-    let targetTypeSyntax ← PrettyPrinter.delab targetType
+    -- let targetTypeSyntax ← PrettyPrinter.delab targetType
+    let targetTypeSyntax := outputType.get!
 
     -- Determine the appropriate type of the final producer
     -- (either `Plausible.Gen α` or `ExceptT GenError Enum α`)
@@ -170,9 +173,11 @@ def mkConstrainedProducerTypeClassInstance
       | .Generator => `($genTypeConstructor $targetTypeSyntax)
       | .Enumerator => `($exceptTTypeConstructor $genErrorType $enumTypeConstructor $targetTypeSyntax)
 
+    let arbitraryTypeParamInstances ← mkTypeClassInstanceBinders typeParams #[``Plausible.Arbitrary, ``DecidableEq]
+
     -- Produce an instance of the appropriate typeclass containing the definition for the derived producer
-    `(instance : $producerTypeClass $targetTypeSyntax (fun $(mkIdent targetVar) => $(mkIdent inductiveName) $args*) where
+    `(instance $arbitraryTypeParamInstances:bracketedBinder* : $producerTypeClass $targetTypeSyntax (fun $(mkIdent targetVar) => @$(mkIdent inductiveName) $args*) where
         $producerTypeClassFunction:ident :=
-          let rec $innerFunctionIdent:ident $innerParams* : $optionTProducerType :=
+          let rec $innerFunctionIdent:ident $innerParams* $arbitraryTypeParamInstances:bracketedBinder* : $optionTProducerType :=
             $matchExpr
           fun $freshSizeIdent => $innerFunctionIdent $freshSizeIdent $freshSizeIdent $outerParams*)

--- a/Plausible/Chamelean/Schedules.lean
+++ b/Plausible/Chamelean/Schedules.lean
@@ -195,32 +195,7 @@ def updateNonRecSource (k : UnknownMap) (hyp : HypothesisExpr) : UnifyM Source :
 def updateSource (k : UnknownMap) (src : Source) : UnifyM Source := do
   match src with
   | .NonRec hyp => do
-    -- let hypExpr := toExpr hyp
-
-    -- -- To do so, we first extract the constructor in the hypothesis
-    -- -- and see if it corresponds to a type constructor for a parameterized type `inductive` type (e.g. `List`)
-    -- -- If yes, we can just return the source as is, since the source is just the name of a type
-    -- let (ctor, _) := hypExpr.getAppFnArgs
-
-    -- try (do
-    --   -- Determine the return type of the constructor in the hypothesis
-    --   let inductiveVal ← getConstInfoInduct ctor
-    --   let ctorTy := inductiveVal.type
-    --   let returnType ← Array.back! <$> getComponentsOfArrowType ctorTy
-    --   -- If the return type is *not* `Prop`, then the `Source` is
-    --   -- a generator for some inductive type (as opposed to an inductive `Prop`),
-    --   -- so we don't need to update the source
-    --   if (not returnType.isProp) then
-    --     pure src
-    --   else
-    --     updateNonRecSource k hyp)
-    -- catch _ =>
-    --   -- `ctor` is not an inductive type (calling Lean's `getConstInfoInduct` function raised an exception)
-    --   -- This means we have a hypothesis which is *not* an application of some inductive type/proposition,
-    --   -- i.e. we can just update the variables in the `hyp` w/ the result of unification
-    --   trace[plausible.deriving.arbitrary] m!"Non rec non ind hyp: {hyp}"
-      updateNonRecSource k hyp
-
+    updateNonRecSource k hyp
   | .Rec r tys => do
     let updatedTys ← List.mapM (UnifyM.updateConstructorArg k) tys
     return .Rec r updatedTys

--- a/Plausible/Chamelean/Schedules.lean
+++ b/Plausible/Chamelean/Schedules.lean
@@ -169,9 +169,9 @@ partial def exprToConstructorExpr (e : Expr) : MetaM ConstructorExpr := do
 
 /-- Converts an `Expr` to a `HypothesisExpr` if it is a variable or application of type constructor or function to constructor expressions else throws error -/
 def exprToHypothesisExpr (e : Expr) : MetaM HypothesisExpr := do
-  trace[plausible.deriving.arbitrary] s!"Converting {e} to Hypexpr"
+  trace[plausible.deriving.arbitrary] m!"Converting {e} to Hypexpr"
   let e ← Lean.Meta.withTransparency .reducible <| Meta.whnf e
-  trace[plausible.deriving.arbitrary] s!"Converting {e} to Hypexpr after whnf"
+  trace[plausible.deriving.arbitrary] m!"Converting {e} to Hypexpr after whnf"
   if e.isApp || e.isConst then
     let (ctorName, args) := e.getAppFnArgs
     let env ← getEnv
@@ -187,36 +187,38 @@ def exprToHypothesisExpr (e : Expr) : MetaM HypothesisExpr := do
     with the result of unification (provided via the `UnifyM` monad) -/
 def updateNonRecSource (k : UnknownMap) (hyp : HypothesisExpr) : UnifyM Source := do
   let (ctorName, args) := hyp
+  let updatedName ← UnifyM.findCanonicalUnknown k ctorName
   let updatedArgs ← List.mapM (UnifyM.updateConstructorArg k) args
-  return .NonRec (ctorName, updatedArgs)
+  return .NonRec (updatedName, updatedArgs)
 
 /-- Updates a `Source` with the result of unification as contained in the `UnknownMap` -/
 def updateSource (k : UnknownMap) (src : Source) : UnifyM Source := do
   match src with
   | .NonRec hyp => do
-    let hypExpr := toExpr hyp
+    -- let hypExpr := toExpr hyp
 
-    -- To do so, we first extract the constructor in the hypothesis
-    -- and see if it corresponds to a type constructor for a parameterized type `inductive` type (e.g. `List`)
-    -- If yes, we can just return the source as is, since the source is just the name of a type
-    let (ctor, _) := hypExpr.getAppFnArgs
+    -- -- To do so, we first extract the constructor in the hypothesis
+    -- -- and see if it corresponds to a type constructor for a parameterized type `inductive` type (e.g. `List`)
+    -- -- If yes, we can just return the source as is, since the source is just the name of a type
+    -- let (ctor, _) := hypExpr.getAppFnArgs
 
-    try (do
-      -- Determine the return type of the constructor in the hypothesis
-      let inductiveVal ← getConstInfoInduct ctor
-      let ctorTy := inductiveVal.type
-      let returnType ← Array.back! <$> getComponentsOfArrowType ctorTy
-      -- If the return type is *not* `Prop`, then the `Source` is
-      -- a generator for some inductive type (as opposed to an inductive `Prop`),
-      -- so we don't need to update the source
-      if (not returnType.isProp) then
-        pure src
-      else
-        updateNonRecSource k hyp)
-    catch _ =>
-      -- `ctor` is not an inductive type (calling Lean's `getConstInfoInduct` function raised an exception)
-      -- This means we have a hypothesis which is *not* an application of some inductive type/proposition,
-      -- i.e. we can just update the variables in the `hyp` w/ the result of unification
+    -- try (do
+    --   -- Determine the return type of the constructor in the hypothesis
+    --   let inductiveVal ← getConstInfoInduct ctor
+    --   let ctorTy := inductiveVal.type
+    --   let returnType ← Array.back! <$> getComponentsOfArrowType ctorTy
+    --   -- If the return type is *not* `Prop`, then the `Source` is
+    --   -- a generator for some inductive type (as opposed to an inductive `Prop`),
+    --   -- so we don't need to update the source
+    --   if (not returnType.isProp) then
+    --     pure src
+    --   else
+    --     updateNonRecSource k hyp)
+    -- catch _ =>
+    --   -- `ctor` is not an inductive type (calling Lean's `getConstInfoInduct` function raised an exception)
+    --   -- This means we have a hypothesis which is *not* an application of some inductive type/proposition,
+    --   -- i.e. we can just update the variables in the `hyp` w/ the result of unification
+    --   trace[plausible.deriving.arbitrary] m!"Non rec non ind hyp: {hyp}"
       updateNonRecSource k hyp
 
   | .Rec r tys => do
@@ -238,7 +240,8 @@ def updateScheduleSteps (scheduleSteps : List ScheduleStep) : UnifyM (List Sched
     | .SuchThat unknownsAndTypes src dst => do
       let updatedUnknownsAndTypes ← unknownsAndTypes.mapM (fun (u, ty) => do
         let u' ← UnifyM.findCanonicalUnknown k u
-        return (u', ty))
+        let ty' ← ty.mapM <| UnifyM.updateConstructorArg k
+        return (u', ty'))
       let updatedSource ← updateSource k src
       return .SuchThat updatedUnknownsAndTypes updatedSource dst
     | .Check src polarity => do

--- a/Plausible/Chamelean/UnificationMonad.lean
+++ b/Plausible/Chamelean/UnificationMonad.lean
@@ -418,11 +418,9 @@ partial def updateConstructorArg (k : UnknownMap) (ctorArg : ConstructorExpr) : 
       return (.Unknown canonicalUnknown)
     else
       return (.Unknown arg)
-  | .Ctor ctorName args
-  | .TyCtor ctorName args
-  | .FuncApp ctorName args =>
-    let updatedArgs ← args.mapM (updateConstructorArg k)
-    return (.Ctor ctorName updatedArgs)
+  | .Ctor ctorName args => return .Ctor ctorName (← args.mapM $ updateConstructorArg k)
+  | .TyCtor ctorName args => return .TyCtor ctorName (← args.mapM $ updateConstructorArg k)
+  | .FuncApp ctorName args => return .FuncApp ctorName (← args.mapM $ updateConstructorArg k)
   | .Lit l => return .Lit l
 
 /-- `updatePattern k p` uses the `UnknownMap` `k` to rewrite any unknowns that appear in the

--- a/Test/DeriveArbitrarySuchThat/DependentArgs.lean
+++ b/Test/DeriveArbitrarySuchThat/DependentArgs.lean
@@ -1,5 +1,7 @@
 import Plausible.Chamelean.ArbitrarySizedSuchThat
 import Plausible.Chamelean.DeriveConstrainedProducer
+import Plausible.Chamelean.EnumeratorCombinators
+import Plausible.Chamelean.DeriveChecker
 import Plausible.Attr
 
 set_option guard_msgs.diff true
@@ -27,35 +29,11 @@ derive_generator (fun α l => ∃ n, @HasDep α l n)
 inductive HasClassDep {α : Type} [h : DecidableEq α] : Nat → Prop where
 | foo (a b : α) : a = b → HasClassDep 0
 
-/--
-error: Function expected at
-  HasClassDep α_1
-but this term has type
-  Prop
-
-Note: Expected a function because this term is being applied to the argument
-  inst_1
----
-error: Unknown identifier `α`
----
-error: Application type mismatch: The argument
-  α_1
-has type
-  Nat
-of sort `Type` but is expected to have type
-  Type
-of sort `Type 1` in the application
-  aux_arb size size α_1
----
-error: Unknown identifier `inst_1`
----
-error: Unknown identifier `α`
----
-error: Unknown identifier `α`
--/
 #guard_msgs(drop info, error) in
 derive_generator (fun α inst => ∃ n, @HasClassDep α inst n)
 
+#guard_msgs(error, drop warning, drop info) in
+derive_checker fun α inst n => @HasClassDep α inst n
 
 def f : Nat → Nat := fun _ => 0
 

--- a/Test/DeriveArbitrarySuchThat/DependentArgs.lean
+++ b/Test/DeriveArbitrarySuchThat/DependentArgs.lean
@@ -35,6 +35,9 @@ derive_generator (fun α inst => ∃ n, @HasClassDep α inst n)
 #guard_msgs(error, drop warning, drop info) in
 derive_checker fun α inst n => @HasClassDep α inst n
 
+#guard_msgs(drop info, error) in
+derive_enumerator (fun α inst => ∃ n, @HasClassDep α inst n)
+
 def f : Nat → Nat := fun _ => 0
 
 inductive HasCall : Nat → Prop where
@@ -42,3 +45,6 @@ inductive HasCall : Nat → Prop where
 
 #guard_msgs(error, whitespace:=lax, drop info) in
 derive_generator ∃ n, HasCall n
+
+#guard_msgs(error, whitespace:=lax, drop info) in
+derive_enumerator ∃ n, HasCall n

--- a/Test/DeriveArbitrarySuchThat/NEqGenerator.lean
+++ b/Test/DeriveArbitrarySuchThat/NEqGenerator.lean
@@ -2,6 +2,7 @@ import Plausible.Gen
 import Plausible.Chamelean.DecOpt
 import Plausible.Chamelean.ArbitrarySizedSuchThat
 import Plausible.Chamelean.DeriveConstrainedProducer
+import Plausible.Chamelean.DeriveChecker
 import Test.CommonDefinitions.BinaryTree
 import Plausible.Attr
 
@@ -40,34 +41,46 @@ inductive usesNeq' : Nat × Nat → Prop where
 derive_generator ∃ a, usesNeq' a
 
 inductive Diag : (α : Type u) → α → α × α → Prop where
-| c : Diag α a (a, a)
+| c : Diag α a (b, b)
 
-/--  error: Application type mismatch: The argument
-  a_1
- has type
-   α
-but is expected to have type
-  α_1
-   in the application
-   Diag α_1 a_1
- ---
- error: unknown universe level `u`
- ---
- error: Redundant alternative: Any expression matching
-   _
- will match one of the preceding alternatives
- ---
- error: Redundant alternative: Any expression matching
-   _
- will match one of the preceding alternatives
- ---
- error: (kernel) declaration has metavariables 'inst.aux_arb✝'-/
+-- set_option trace.plausible.deriving.arbitrary true
+
+/--
+error: Redundant alternative: Any expression matching
+  _
+will match one of the preceding alternatives
+---
+error: Redundant alternative: Any expression matching
+  _
+will match one of the preceding alternatives-/
 #guard_msgs(error, drop info, whitespace := lax) in
-derive_generator fun α b => ∃ a, Diag α a b
+derive_generator fun γ p => ∃ g, Diag γ g p
 
+/-- error: Redundant alternative: Any expression matching
+  _
+will match one of the preceding alternatives
+
+---
+
+error: Redundant alternative: Any expression matching
+  _
+will match one of the preceding alternatives -/
+#guard_msgs(error, drop info, whitespace := lax) in
+derive_checker fun γ g p => Diag γ g p
 
 inductive usesVec : _ → Prop where
 | c {a b : Nat} : usesVec #v[a,b,a]
 
 #guard_msgs(drop error, drop info, whitespace := lax) in
 derive_generator ∃ a, usesVec a
+
+inductive TypeChange : Type u → Nat → Prop where
+| ennd : TypeChange (((α × α) × (α × α)) × (((α × α) × (α × α)))) 3
+| change : TypeChange (α × α) (n + 1) → TypeChange α n
+
+example : TypeChange (Nat × Nat) 1 := .ennd |>.change.change
+
+example : TypeChange Nat 0 := .ennd |>.change.change.change
+
+#guard_msgs(drop error, drop info) in
+derive_generator fun α => ∃ n, TypeChange α n


### PR DESCRIPTION
Consider the following inductive:

```
inductive Diag : (α : Type u) → α → α × α → Prop where
| c : Diag α a (b, b)
```

A good generator for `Diag`, supposing we output the second argument and took as input the first argument, the type `α`, and the third argument, the pair of `α`s . A good generator to satisfy constructor `c` would need to check that both sides of the pair are equal, and therefore depend on a `DecidableEq α` instance, and generate an arbitrary `α` to return `a`, requiring an `Arbitrary α` instance. This PR automatically supplies these, and properly substitutes fresh variable names into types when necessary, thus supporting type arguments.